### PR TITLE
Add option for batch update on activities

### DIFF
--- a/docs_code_snippets/03_01_activities.dart
+++ b/docs_code_snippets/03_01_activities.dart
@@ -100,9 +100,7 @@ Future<void> updatingAndDeletingActivities() async {
 
   // Batch delete activities
   await client.deleteActivities(
-    request: const DeleteActivitiesRequest(
-      ids: ['123', '456'],
-      hardDelete: false,
-    ),
+    ids: ['123', '456'],
+    hardDelete: false,
   );
 }

--- a/docs_code_snippets/04_01_feeds.dart
+++ b/docs_code_snippets/04_01_feeds.dart
@@ -85,27 +85,28 @@ Future<void> feedPagination() async {
 Future<void> filteringExamples() async {
   // Add a few activities
   const feedId = FeedId(group: 'user', id: 'john');
-  await client.upsertActivities([
-    ActivityRequest(
-      feeds: [feedId.rawValue],
-      filterTags: const ['green', 'blue'],
-      text: 'first',
-      type: 'post',
-    ),
-    ActivityRequest(
-      feeds: [feedId.rawValue],
-      filterTags: const ['yellow', 'blue'],
-      text: 'second',
-      type: 'post',
-    ),
-    ActivityRequest(
-      feeds: [feedId.rawValue],
-      filterTags: const ['orange'],
-      text: 'third',
-      type: 'activity',
-    ),
-  ]);
-
+  await client.upsertActivities(
+    activities: [
+      ActivityRequest(
+        feeds: [feedId.rawValue],
+        filterTags: const ['green', 'blue'],
+        text: 'first',
+        type: 'post',
+      ),
+      ActivityRequest(
+        feeds: [feedId.rawValue],
+        filterTags: const ['yellow', 'blue'],
+        text: 'second',
+        type: 'post',
+      ),
+      ActivityRequest(
+        feeds: [feedId.rawValue],
+        filterTags: const ['orange'],
+        text: 'third',
+        type: 'activity',
+      ),
+    ],
+  );
   // Now read the feed, this will fetch activity 1 and 2
   final query = FeedQuery(
     fid: feedId,

--- a/packages/stream_feeds/lib/src/client/feeds_client_impl.dart
+++ b/packages/stream_feeds/lib/src/client/feeds_client_impl.dart
@@ -319,6 +319,26 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
   }
 
   @override
+  Future<Result<List<ActivityData>>> upsertActivities({
+    required List<api.ActivityRequest> activities,
+  }) {
+    return _activitiesRepository.upsertActivities(activities);
+  }
+
+  @override
+  Future<Result<api.DeleteActivitiesResponse>> deleteActivities({
+    required List<String> ids,
+    bool? hardDelete,
+  }) {
+    return _activitiesRepository.deleteActivities(
+      deleteActivitiesRequest: api.DeleteActivitiesRequest(
+        ids: ids,
+        hardDelete: hardDelete,
+      ),
+    );
+  }
+
+  @override
   ActivityReactionList activityReactionList(ActivityReactionsQuery query) {
     return ActivityReactionList(
       query: query,

--- a/packages/stream_feeds/lib/src/feeds_client.dart
+++ b/packages/stream_feeds/lib/src/feeds_client.dart
@@ -3,6 +3,7 @@ import 'package:stream_core/stream_core.dart';
 import 'client/feeds_client_impl.dart';
 import 'client/moderation_client.dart';
 import 'generated/api/api.dart' as api;
+import 'models/activity_data.dart';
 import 'models/app_data.dart';
 import 'models/feed_id.dart';
 import 'models/feeds_config.dart';
@@ -326,6 +327,51 @@ abstract interface class StreamFeedsClient {
   /// Returns an [ActivityList] instance that can be used to interact with the collection of
   /// activities.
   ActivityList activityList(ActivitiesQuery query);
+
+  /// Upserts (inserts or updates) multiple activities.
+  ///
+  /// Creates or updates the provided [activities] in a single batch operation.
+  ///
+  /// Example:
+  /// ```dart
+  /// final upsertedActivities = await client.upsertActivities(
+  ///   activities: [
+  ///     const ActivityRequest(
+  ///       feeds: ['user:123'],
+  ///       id: '1',
+  ///       text: 'hi',
+  ///       type: 'post',
+  ///     ),
+  ///     const ActivityRequest(
+  ///       feeds: ['user:456'],
+  ///       id: '2',
+  ///       text: 'hi',
+  ///       type: 'post',
+  ///     ),
+  ///   ],
+  /// );
+  ///```
+  ///
+  /// Returns a [Result] containing the list of upserted [ActivityData] or an error.
+  Future<Result<List<ActivityData>>> upsertActivities({
+    required List<api.ActivityRequest> activities,
+  });
+
+  /// Deletes multiple activities.
+  ///
+  /// Deletes the provided [ids] in a single batch operation.
+  ///
+  ///```dart
+  ///await client.deleteActivities(
+  ///  ids: ['123', '456'],
+  ///  hardDelete: false,
+  ///);
+  ///
+  /// Returns a [Result] containing the list of deleted activity ids or an error.
+  Future<Result<api.DeleteActivitiesResponse>> deleteActivities({
+    required List<String> ids,
+    bool? hardDelete,
+  });
 
   /// Creates an activity reaction list instance based on the provided [query].
   ///

--- a/packages/stream_feeds/lib/src/repository/activities_repository.dart
+++ b/packages/stream_feeds/lib/src/repository/activities_repository.dart
@@ -107,6 +107,19 @@ class ActivitiesRepository {
     );
   }
 
+  /// Deletes multiple activities.
+  ///
+  /// Deletes the provided [deleteActivitiesRequest.ids] in a single batch operation.
+  ///
+  /// Returns a [Result] containing the list of deleted activity ids or an error.
+  Future<Result<api.DeleteActivitiesResponse>> deleteActivities({
+    required api.DeleteActivitiesRequest deleteActivitiesRequest,
+  }) {
+    return _api.deleteActivities(
+      deleteActivitiesRequest: deleteActivitiesRequest,
+    );
+  }
+
   /// Pins an activity to a feed.
   ///
   /// Pins the activity with [activityId] to the specified [fid] feed.


### PR DESCRIPTION
# Submit a pull request


## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
<!-- 
Describe how these code changes fix the issue or how the feature works.
Also try to give instructions how this can be tested.
-->
This adds options to the client to batch upsert and/or delete activities
