### PR TITLE
refactor(llc): Type-safe filter fields in queries

### DIFF
--- a/docs_code_snippets/03_02_querying_activities.dart
+++ b/docs_code_snippets/03_02_querying_activities.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_local_variable, file_names
+// ignore_for_file: unused_local_variable, file_names, avoid_redundant_argument_values
 
 import 'package:stream_feeds/stream_feeds.dart';
 
@@ -7,7 +7,7 @@ late Feed feed;
 
 Future<void> activitySearchAndQueries() async {
   final query = ActivitiesQuery(
-    filter: Filter.equal(ActivitiesFilterField.type, 'post'),
+    filter: const Filter.equal(ActivitiesFilterField.type, 'post'),
     sort: [ActivitiesSort.desc(ActivitiesSortField.createdAt)],
     limit: 10,
   );
@@ -18,7 +18,7 @@ Future<void> activitySearchAndQueries() async {
 
 Future<void> queryActivitiesByText() async {
   // search for activities where the text includes the word 'popularity'.
-  final query = ActivitiesQuery(
+  const query = ActivitiesQuery(
     filter: Filter.equal(ActivitiesFilterField.text, 'popularity'),
   );
 
@@ -28,7 +28,10 @@ Future<void> queryActivitiesByText() async {
 
 Future<void> queryActivitiesBySearchData() async {
   // search for activities associated with the campaign ID 'spring-sale-2025'
-  final searchValue = {'campaign': {'id': 'spring-sale-2025'}};
+  final searchValue = {
+    'campaign': {'id': 'spring-sale-2025'},
+  };
+
   final query = ActivitiesQuery(
     filter: Filter.contains(ActivitiesFilterField.searchData, searchValue),
   );
@@ -37,8 +40,11 @@ Future<void> queryActivitiesBySearchData() async {
   final activities = await activityList.get();
 
   // search for activities where the campaign took place in a mall
-  final query2 = ActivitiesQuery(
-    filter: Filter.pathExists(ActivitiesFilterField.searchData, 'campaign.location.mall'),
+  const query2 = ActivitiesQuery(
+    filter: Filter.pathExists(
+      ActivitiesFilterField.searchData,
+      'campaign.location.mall',
+    ),
   );
 
   final activityList2 = client.activityList(query2);

--- a/docs_code_snippets/04_01_feeds.dart
+++ b/docs_code_snippets/04_01_feeds.dart
@@ -36,12 +36,12 @@ Future<void> readingAFeed() async {
 }
 
 Future<void> readingAFeedMoreOptions() async {
-  final query = FeedQuery(
-    fid: const FeedId(group: 'user', id: 'john'),
+  const query = FeedQuery(
+    fid: FeedId(group: 'user', id: 'john'),
     // filter activities with filter tag green
     activityFilter: Filter.in_(
       ActivitiesFilterField.filterTags,
-      const ['green'],
+      ['green'],
     ),
     activityLimit: 10,
     // additional data used for ranking
@@ -108,11 +108,9 @@ Future<void> filteringExamples() async {
     ],
   );
   // Now read the feed, this will fetch activity 1 and 2
-  final query = FeedQuery(
+  const query = FeedQuery(
     fid: feedId,
-    activityFilter: Filter.in_(ActivitiesFilterField.filterTags, const [
-      'blue',
-    ]),
+    activityFilter: Filter.in_(ActivitiesFilterField.filterTags, ['blue']),
   );
 
   final feed = client.feedFromQuery(query);
@@ -123,20 +121,21 @@ Future<void> filteringExamples() async {
 
 Future<void> moreComplexFilterExamples() async {
   // Get all the activities where tags contain "green" and type is "post" or tag contains "orange" and type is "activity"
-  final query = FeedQuery(
-    fid: const FeedId(group: 'user', id: 'john'),
+  const query = FeedQuery(
+    fid: FeedId(group: 'user', id: 'john'),
     activityFilter: Filter.or([
       Filter.and([
-        Filter.in_(ActivitiesFilterField.filterTags, const ['green']),
+        Filter.in_(ActivitiesFilterField.filterTags, ['green']),
         Filter.equal(ActivitiesFilterField.type, 'post'),
       ]),
       Filter.and([
-        Filter.in_(ActivitiesFilterField.filterTags, const ['orange']),
+        Filter.in_(ActivitiesFilterField.filterTags, ['orange']),
         Filter.equal(ActivitiesFilterField.type, 'activity'),
       ]),
     ]),
   );
 
+  final feed = client.feedFromQuery(query);
   await feed.getOrCreate();
   final activities = feed.state.activities;
 }
@@ -199,7 +198,7 @@ Future<void> memberInvites() async {
 
 Future<void> queryMyFeeds() async {
   final query = FeedsQuery(
-    filter: Filter.equal(FeedsFilterField.createdById, 'john'),
+    filter: const Filter.equal(FeedsFilterField.createdById, 'john'),
     sort: [FeedsSort.desc(FeedsSortField.createdAt)],
     limit: 10,
     watch: true,
@@ -217,7 +216,7 @@ Future<void> queryMyFeeds() async {
 }
 
 Future<void> queryFeedsWhereIAmAMember() async {
-  final query = FeedsQuery(
+  const query = FeedsQuery(
     filter: Filter.contains(FeedsFilterField.members, 'john'),
   );
   final feedList = client.feedList(query);
@@ -225,7 +224,7 @@ Future<void> queryFeedsWhereIAmAMember() async {
 }
 
 Future<void> queryFeedsByNameOrVisibility() async {
-  final sportsQuery = FeedsQuery(
+  const sportsQuery = FeedsQuery(
     filter: Filter.and([
       Filter.equal(FeedsFilterField.visibility, 'public'),
       Filter.query(FeedsFilterField.name, 'Sports'),
@@ -235,7 +234,7 @@ Future<void> queryFeedsByNameOrVisibility() async {
   final sportsFeedList = client.feedList(sportsQuery);
   final sportsFeeds = await sportsFeedList.get();
 
-  final techQuery = FeedsQuery(
+  const techQuery = FeedsQuery(
     filter: Filter.and([
       Filter.equal(FeedsFilterField.visibility, 'public'),
       Filter.autoComplete(FeedsFilterField.description, 'tech'),
@@ -247,7 +246,7 @@ Future<void> queryFeedsByNameOrVisibility() async {
 }
 
 Future<void> queryFeedsByCreatorName() async {
-  final query = FeedsQuery(
+  const query = FeedsQuery(
     filter: Filter.and([
       Filter.equal(FeedsFilterField.visibility, 'public'),
       Filter.query(FeedsFilterField.createdByName, 'Thompson'),

--- a/melos.yaml
+++ b/melos.yaml
@@ -46,7 +46,7 @@ command:
       stream_core:
         git:
           url: https://github.com/GetStream/stream-core-flutter.git
-          ref: 5acdcb8e378548372f7dbb6326c518edcf832d10
+          ref: 280b1045e39388668fd060439259831611b51b5a
           path: packages/stream_core
 
     # List of all the dev_dependencies used in the project.

--- a/packages/stream_feeds/lib/src/generated/api/model/activity_added_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/activity_added_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$ActivityAddedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ActivityAddedEvent &&
-            super == other &&
             (identical(other.activity, activity) ||
                 other.activity == activity) &&
             (identical(other.createdAt, createdAt) ||
@@ -55,7 +54,6 @@ mixin _$ActivityAddedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       activity,
       createdAt,
       const DeepCollectionEquality().hash(custom),

--- a/packages/stream_feeds/lib/src/generated/api/model/activity_deleted_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/activity_deleted_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$ActivityDeletedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ActivityDeletedEvent &&
-            super == other &&
             (identical(other.activity, activity) ||
                 other.activity == activity) &&
             (identical(other.createdAt, createdAt) ||
@@ -55,7 +54,6 @@ mixin _$ActivityDeletedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       activity,
       createdAt,
       const DeepCollectionEquality().hash(custom),

--- a/packages/stream_feeds/lib/src/generated/api/model/activity_mark_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/activity_mark_event.freezed.dart
@@ -41,7 +41,6 @@ mixin _$ActivityMarkEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ActivityMarkEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -65,7 +64,6 @@ mixin _$ActivityMarkEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/activity_pinned_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/activity_pinned_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$ActivityPinnedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ActivityPinnedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -55,7 +54,6 @@ mixin _$ActivityPinnedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/activity_reaction_added_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/activity_reaction_added_event.freezed.dart
@@ -39,7 +39,6 @@ mixin _$ActivityReactionAddedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ActivityReactionAddedEvent &&
-            super == other &&
             (identical(other.activity, activity) ||
                 other.activity == activity) &&
             (identical(other.createdAt, createdAt) ||
@@ -59,7 +58,6 @@ mixin _$ActivityReactionAddedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       activity,
       createdAt,
       const DeepCollectionEquality().hash(custom),

--- a/packages/stream_feeds/lib/src/generated/api/model/activity_reaction_deleted_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/activity_reaction_deleted_event.freezed.dart
@@ -39,7 +39,6 @@ mixin _$ActivityReactionDeletedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ActivityReactionDeletedEvent &&
-            super == other &&
             (identical(other.activity, activity) ||
                 other.activity == activity) &&
             (identical(other.createdAt, createdAt) ||
@@ -59,7 +58,6 @@ mixin _$ActivityReactionDeletedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       activity,
       createdAt,
       const DeepCollectionEquality().hash(custom),

--- a/packages/stream_feeds/lib/src/generated/api/model/activity_reaction_updated_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/activity_reaction_updated_event.freezed.dart
@@ -39,7 +39,6 @@ mixin _$ActivityReactionUpdatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ActivityReactionUpdatedEvent &&
-            super == other &&
             (identical(other.activity, activity) ||
                 other.activity == activity) &&
             (identical(other.createdAt, createdAt) ||
@@ -59,7 +58,6 @@ mixin _$ActivityReactionUpdatedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       activity,
       createdAt,
       const DeepCollectionEquality().hash(custom),

--- a/packages/stream_feeds/lib/src/generated/api/model/activity_removed_from_feed_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/activity_removed_from_feed_event.freezed.dart
@@ -38,7 +38,6 @@ mixin _$ActivityRemovedFromFeedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ActivityRemovedFromFeedEvent &&
-            super == other &&
             (identical(other.activity, activity) ||
                 other.activity == activity) &&
             (identical(other.createdAt, createdAt) ||
@@ -56,7 +55,6 @@ mixin _$ActivityRemovedFromFeedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       activity,
       createdAt,
       const DeepCollectionEquality().hash(custom),

--- a/packages/stream_feeds/lib/src/generated/api/model/activity_unpinned_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/activity_unpinned_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$ActivityUnpinnedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ActivityUnpinnedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -55,7 +54,6 @@ mixin _$ActivityUnpinnedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/activity_updated_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/activity_updated_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$ActivityUpdatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ActivityUpdatedEvent &&
-            super == other &&
             (identical(other.activity, activity) ||
                 other.activity == activity) &&
             (identical(other.createdAt, createdAt) ||
@@ -55,7 +54,6 @@ mixin _$ActivityUpdatedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       activity,
       createdAt,
       const DeepCollectionEquality().hash(custom),

--- a/packages/stream_feeds/lib/src/generated/api/model/app_updated_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/app_updated_event.freezed.dart
@@ -34,7 +34,6 @@ mixin _$AppUpdatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is AppUpdatedEvent &&
-            super == other &&
             (identical(other.app, app) || other.app == app) &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
@@ -45,7 +44,7 @@ mixin _$AppUpdatedEvent {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, super.hashCode, app, createdAt,
+  int get hashCode => Object.hash(runtimeType, app, createdAt,
       const DeepCollectionEquality().hash(custom), receivedAt, type);
 
   @override

--- a/packages/stream_feeds/lib/src/generated/api/model/bookmark_added_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/bookmark_added_event.freezed.dart
@@ -35,7 +35,6 @@ mixin _$BookmarkAddedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is BookmarkAddedEvent &&
-            super == other &&
             (identical(other.bookmark, bookmark) ||
                 other.bookmark == bookmark) &&
             (identical(other.createdAt, createdAt) ||
@@ -48,15 +47,8 @@ mixin _$BookmarkAddedEvent {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      super.hashCode,
-      bookmark,
-      createdAt,
-      const DeepCollectionEquality().hash(custom),
-      receivedAt,
-      type,
-      user);
+  int get hashCode => Object.hash(runtimeType, bookmark, createdAt,
+      const DeepCollectionEquality().hash(custom), receivedAt, type, user);
 
   @override
   String toString() {

--- a/packages/stream_feeds/lib/src/generated/api/model/bookmark_deleted_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/bookmark_deleted_event.freezed.dart
@@ -35,7 +35,6 @@ mixin _$BookmarkDeletedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is BookmarkDeletedEvent &&
-            super == other &&
             (identical(other.bookmark, bookmark) ||
                 other.bookmark == bookmark) &&
             (identical(other.createdAt, createdAt) ||
@@ -48,15 +47,8 @@ mixin _$BookmarkDeletedEvent {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      super.hashCode,
-      bookmark,
-      createdAt,
-      const DeepCollectionEquality().hash(custom),
-      receivedAt,
-      type,
-      user);
+  int get hashCode => Object.hash(runtimeType, bookmark, createdAt,
+      const DeepCollectionEquality().hash(custom), receivedAt, type, user);
 
   @override
   String toString() {

--- a/packages/stream_feeds/lib/src/generated/api/model/bookmark_folder_deleted_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/bookmark_folder_deleted_event.freezed.dart
@@ -36,7 +36,6 @@ mixin _$BookmarkFolderDeletedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is BookmarkFolderDeletedEvent &&
-            super == other &&
             (identical(other.bookmarkFolder, bookmarkFolder) ||
                 other.bookmarkFolder == bookmarkFolder) &&
             (identical(other.createdAt, createdAt) ||
@@ -49,15 +48,8 @@ mixin _$BookmarkFolderDeletedEvent {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      super.hashCode,
-      bookmarkFolder,
-      createdAt,
-      const DeepCollectionEquality().hash(custom),
-      receivedAt,
-      type,
-      user);
+  int get hashCode => Object.hash(runtimeType, bookmarkFolder, createdAt,
+      const DeepCollectionEquality().hash(custom), receivedAt, type, user);
 
   @override
   String toString() {

--- a/packages/stream_feeds/lib/src/generated/api/model/bookmark_folder_updated_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/bookmark_folder_updated_event.freezed.dart
@@ -36,7 +36,6 @@ mixin _$BookmarkFolderUpdatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is BookmarkFolderUpdatedEvent &&
-            super == other &&
             (identical(other.bookmarkFolder, bookmarkFolder) ||
                 other.bookmarkFolder == bookmarkFolder) &&
             (identical(other.createdAt, createdAt) ||
@@ -49,15 +48,8 @@ mixin _$BookmarkFolderUpdatedEvent {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      super.hashCode,
-      bookmarkFolder,
-      createdAt,
-      const DeepCollectionEquality().hash(custom),
-      receivedAt,
-      type,
-      user);
+  int get hashCode => Object.hash(runtimeType, bookmarkFolder, createdAt,
+      const DeepCollectionEquality().hash(custom), receivedAt, type, user);
 
   @override
   String toString() {

--- a/packages/stream_feeds/lib/src/generated/api/model/bookmark_updated_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/bookmark_updated_event.freezed.dart
@@ -35,7 +35,6 @@ mixin _$BookmarkUpdatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is BookmarkUpdatedEvent &&
-            super == other &&
             (identical(other.bookmark, bookmark) ||
                 other.bookmark == bookmark) &&
             (identical(other.createdAt, createdAt) ||
@@ -48,15 +47,8 @@ mixin _$BookmarkUpdatedEvent {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      super.hashCode,
-      bookmark,
-      createdAt,
-      const DeepCollectionEquality().hash(custom),
-      receivedAt,
-      type,
-      user);
+  int get hashCode => Object.hash(runtimeType, bookmark, createdAt,
+      const DeepCollectionEquality().hash(custom), receivedAt, type, user);
 
   @override
   String toString() {

--- a/packages/stream_feeds/lib/src/generated/api/model/comment_added_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/comment_added_event.freezed.dart
@@ -38,7 +38,6 @@ mixin _$CommentAddedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is CommentAddedEvent &&
-            super == other &&
             (identical(other.activity, activity) ||
                 other.activity == activity) &&
             (identical(other.comment, comment) || other.comment == comment) &&
@@ -57,7 +56,6 @@ mixin _$CommentAddedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       activity,
       comment,
       createdAt,

--- a/packages/stream_feeds/lib/src/generated/api/model/comment_deleted_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/comment_deleted_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$CommentDeletedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is CommentDeletedEvent &&
-            super == other &&
             (identical(other.comment, comment) || other.comment == comment) &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
@@ -54,7 +53,6 @@ mixin _$CommentDeletedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       comment,
       createdAt,
       const DeepCollectionEquality().hash(custom),

--- a/packages/stream_feeds/lib/src/generated/api/model/comment_reaction_added_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/comment_reaction_added_event.freezed.dart
@@ -39,7 +39,6 @@ mixin _$CommentReactionAddedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is CommentReactionAddedEvent &&
-            super == other &&
             (identical(other.activity, activity) ||
                 other.activity == activity) &&
             (identical(other.comment, comment) || other.comment == comment) &&
@@ -60,7 +59,6 @@ mixin _$CommentReactionAddedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       activity,
       comment,
       createdAt,

--- a/packages/stream_feeds/lib/src/generated/api/model/comment_reaction_deleted_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/comment_reaction_deleted_event.freezed.dart
@@ -38,7 +38,6 @@ mixin _$CommentReactionDeletedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is CommentReactionDeletedEvent &&
-            super == other &&
             (identical(other.comment, comment) || other.comment == comment) &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
@@ -56,7 +55,6 @@ mixin _$CommentReactionDeletedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       comment,
       createdAt,
       const DeepCollectionEquality().hash(custom),

--- a/packages/stream_feeds/lib/src/generated/api/model/comment_reaction_updated_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/comment_reaction_updated_event.freezed.dart
@@ -40,7 +40,6 @@ mixin _$CommentReactionUpdatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is CommentReactionUpdatedEvent &&
-            super == other &&
             (identical(other.activity, activity) ||
                 other.activity == activity) &&
             (identical(other.comment, comment) || other.comment == comment) &&
@@ -61,7 +60,6 @@ mixin _$CommentReactionUpdatedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       activity,
       comment,
       createdAt,

--- a/packages/stream_feeds/lib/src/generated/api/model/comment_updated_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/comment_updated_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$CommentUpdatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is CommentUpdatedEvent &&
-            super == other &&
             (identical(other.comment, comment) || other.comment == comment) &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
@@ -54,7 +53,6 @@ mixin _$CommentUpdatedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       comment,
       createdAt,
       const DeepCollectionEquality().hash(custom),

--- a/packages/stream_feeds/lib/src/generated/api/model/feed_created_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/feed_created_event.freezed.dart
@@ -38,7 +38,6 @@ mixin _$FeedCreatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is FeedCreatedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -56,7 +55,6 @@ mixin _$FeedCreatedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feed,

--- a/packages/stream_feeds/lib/src/generated/api/model/feed_deleted_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/feed_deleted_event.freezed.dart
@@ -36,7 +36,6 @@ mixin _$FeedDeletedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is FeedDeletedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -52,7 +51,6 @@ mixin _$FeedDeletedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/feed_group_changed_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/feed_group_changed_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$FeedGroupChangedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is FeedGroupChangedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -55,7 +54,6 @@ mixin _$FeedGroupChangedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedGroup,

--- a/packages/stream_feeds/lib/src/generated/api/model/feed_group_deleted_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/feed_group_deleted_event.freezed.dart
@@ -36,7 +36,6 @@ mixin _$FeedGroupDeletedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is FeedGroupDeletedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -52,7 +51,6 @@ mixin _$FeedGroupDeletedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/feed_member_added_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/feed_member_added_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$FeedMemberAddedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is FeedMemberAddedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -54,7 +53,6 @@ mixin _$FeedMemberAddedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/feed_member_removed_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/feed_member_removed_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$FeedMemberRemovedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is FeedMemberRemovedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -55,7 +54,6 @@ mixin _$FeedMemberRemovedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/feed_member_updated_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/feed_member_updated_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$FeedMemberUpdatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is FeedMemberUpdatedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -54,7 +53,6 @@ mixin _$FeedMemberUpdatedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/feed_updated_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/feed_updated_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$FeedUpdatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is FeedUpdatedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -54,7 +53,6 @@ mixin _$FeedUpdatedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feed,

--- a/packages/stream_feeds/lib/src/generated/api/model/follow_created_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/follow_created_event.freezed.dart
@@ -36,7 +36,6 @@ mixin _$FollowCreatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is FollowCreatedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -52,7 +51,6 @@ mixin _$FollowCreatedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/follow_deleted_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/follow_deleted_event.freezed.dart
@@ -36,7 +36,6 @@ mixin _$FollowDeletedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is FollowDeletedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -52,7 +51,6 @@ mixin _$FollowDeletedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/follow_updated_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/follow_updated_event.freezed.dart
@@ -36,7 +36,6 @@ mixin _$FollowUpdatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is FollowUpdatedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -52,7 +51,6 @@ mixin _$FollowUpdatedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/moderation_custom_action_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/moderation_custom_action_event.freezed.dart
@@ -35,7 +35,6 @@ mixin _$ModerationCustomActionEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ModerationCustomActionEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             (identical(other.item, item) || other.item == item) &&
@@ -45,8 +44,8 @@ mixin _$ModerationCustomActionEvent {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, super.hashCode, createdAt, item, message, type, user);
+  int get hashCode =>
+      Object.hash(runtimeType, createdAt, item, message, type, user);
 
   @override
   String toString() {

--- a/packages/stream_feeds/lib/src/generated/api/model/moderation_flagged_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/moderation_flagged_event.freezed.dart
@@ -34,7 +34,6 @@ mixin _$ModerationFlaggedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ModerationFlaggedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             (identical(other.item, item) || other.item == item) &&
@@ -45,8 +44,8 @@ mixin _$ModerationFlaggedEvent {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, super.hashCode, createdAt, item, objectId, type, user);
+  int get hashCode =>
+      Object.hash(runtimeType, createdAt, item, objectId, type, user);
 
   @override
   String toString() {

--- a/packages/stream_feeds/lib/src/generated/api/model/moderation_mark_reviewed_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/moderation_mark_reviewed_event.freezed.dart
@@ -35,7 +35,6 @@ mixin _$ModerationMarkReviewedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ModerationMarkReviewedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             (identical(other.item, item) || other.item == item) &&
@@ -45,8 +44,8 @@ mixin _$ModerationMarkReviewedEvent {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, super.hashCode, createdAt, item, message, type, user);
+  int get hashCode =>
+      Object.hash(runtimeType, createdAt, item, message, type, user);
 
   @override
   String toString() {

--- a/packages/stream_feeds/lib/src/generated/api/model/notification_feed_updated_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/notification_feed_updated_event.freezed.dart
@@ -39,7 +39,6 @@ mixin _$NotificationFeedUpdatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is NotificationFeedUpdatedEvent &&
-            super == other &&
             const DeepCollectionEquality()
                 .equals(other.aggregatedActivities, aggregatedActivities) &&
             (identical(other.createdAt, createdAt) ||
@@ -59,7 +58,6 @@ mixin _$NotificationFeedUpdatedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       const DeepCollectionEquality().hash(aggregatedActivities),
       createdAt,
       const DeepCollectionEquality().hash(custom),

--- a/packages/stream_feeds/lib/src/generated/api/model/poll_closed_feed_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/poll_closed_feed_event.freezed.dart
@@ -36,7 +36,6 @@ mixin _$PollClosedFeedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is PollClosedFeedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -52,7 +51,6 @@ mixin _$PollClosedFeedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/poll_deleted_feed_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/poll_deleted_feed_event.freezed.dart
@@ -36,7 +36,6 @@ mixin _$PollDeletedFeedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is PollDeletedFeedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -52,7 +51,6 @@ mixin _$PollDeletedFeedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/poll_updated_feed_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/poll_updated_feed_event.freezed.dart
@@ -36,7 +36,6 @@ mixin _$PollUpdatedFeedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is PollUpdatedFeedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -52,7 +51,6 @@ mixin _$PollUpdatedFeedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/poll_vote_casted_feed_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/poll_vote_casted_feed_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$PollVoteCastedFeedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is PollVoteCastedFeedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -55,7 +54,6 @@ mixin _$PollVoteCastedFeedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/poll_vote_changed_feed_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/poll_vote_changed_feed_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$PollVoteChangedFeedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is PollVoteChangedFeedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -55,7 +54,6 @@ mixin _$PollVoteChangedFeedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/poll_vote_removed_feed_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/poll_vote_removed_feed_event.freezed.dart
@@ -37,7 +37,6 @@ mixin _$PollVoteRemovedFeedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is PollVoteRemovedFeedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -55,7 +54,6 @@ mixin _$PollVoteRemovedFeedEvent {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      super.hashCode,
       createdAt,
       const DeepCollectionEquality().hash(custom),
       feedVisibility,

--- a/packages/stream_feeds/lib/src/generated/api/model/user_banned_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/user_banned_event.freezed.dart
@@ -40,7 +40,6 @@ mixin _$UserBannedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is UserBannedEvent &&
-            super == other &&
             (identical(other.channelId, channelId) ||
                 other.channelId == channelId) &&
             (identical(other.channelType, channelType) ||
@@ -60,20 +59,8 @@ mixin _$UserBannedEvent {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      super.hashCode,
-      channelId,
-      channelType,
-      cid,
-      createdAt,
-      createdBy,
-      expiration,
-      reason,
-      shadow,
-      team,
-      type,
-      user);
+  int get hashCode => Object.hash(runtimeType, channelId, channelType, cid,
+      createdAt, createdBy, expiration, reason, shadow, team, type, user);
 
   @override
   String toString() {

--- a/packages/stream_feeds/lib/src/generated/api/model/user_deactivated_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/user_deactivated_event.freezed.dart
@@ -33,7 +33,6 @@ mixin _$UserDeactivatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is UserDeactivatedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             (identical(other.createdBy, createdBy) ||
@@ -43,8 +42,8 @@ mixin _$UserDeactivatedEvent {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, super.hashCode, createdAt, createdBy, type, user);
+  int get hashCode =>
+      Object.hash(runtimeType, createdAt, createdBy, type, user);
 
   @override
   String toString() {

--- a/packages/stream_feeds/lib/src/generated/api/model/user_muted_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/user_muted_event.freezed.dart
@@ -34,7 +34,6 @@ mixin _$UserMutedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is UserMutedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             (identical(other.targetUser, targetUser) ||
@@ -46,8 +45,8 @@ mixin _$UserMutedEvent {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, super.hashCode, createdAt,
-      targetUser, const DeepCollectionEquality().hash(targetUsers), type, user);
+  int get hashCode => Object.hash(runtimeType, createdAt, targetUser,
+      const DeepCollectionEquality().hash(targetUsers), type, user);
 
   @override
   String toString() {

--- a/packages/stream_feeds/lib/src/generated/api/model/user_reactivated_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/user_reactivated_event.freezed.dart
@@ -32,7 +32,6 @@ mixin _$UserReactivatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is UserReactivatedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             (identical(other.type, type) || other.type == type) &&
@@ -40,8 +39,7 @@ mixin _$UserReactivatedEvent {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, super.hashCode, createdAt, type, user);
+  int get hashCode => Object.hash(runtimeType, createdAt, type, user);
 
   @override
   String toString() {

--- a/packages/stream_feeds/lib/src/generated/api/model/user_updated_event.freezed.dart
+++ b/packages/stream_feeds/lib/src/generated/api/model/user_updated_event.freezed.dart
@@ -34,7 +34,6 @@ mixin _$UserUpdatedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is UserUpdatedEvent &&
-            super == other &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             const DeepCollectionEquality().equals(other.custom, custom) &&
@@ -45,7 +44,7 @@ mixin _$UserUpdatedEvent {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, super.hashCode, createdAt,
+  int get hashCode => Object.hash(runtimeType, createdAt,
       const DeepCollectionEquality().hash(custom), receivedAt, type, user);
 
   @override

--- a/packages/stream_feeds/lib/src/models/query_configuration.freezed.dart
+++ b/packages/stream_feeds/lib/src/models/query_configuration.freezed.dart
@@ -51,7 +51,7 @@ abstract mixin class $QueryConfigurationCopyWith<S extends Sort<Object>, $Res> {
           $Res Function(QueryConfiguration<S>) _then) =
       _$QueryConfigurationCopyWithImpl;
   @useResult
-  $Res call({Filter? filter, List<S>? sort});
+  $Res call({Filter<FilterField>? filter, List<S>? sort});
 }
 
 /// @nodoc
@@ -74,7 +74,7 @@ class _$QueryConfigurationCopyWithImpl<S extends Sort<Object>, $Res>
       filter: freezed == filter
           ? _self.filter
           : filter // ignore: cast_nullable_to_non_nullable
-              as Filter?,
+              as Filter<FilterField>?,
       sort: freezed == sort
           ? _self.sort
           : sort // ignore: cast_nullable_to_non_nullable

--- a/packages/stream_feeds/lib/src/repository/activities_repository.dart
+++ b/packages/stream_feeds/lib/src/repository/activities_repository.dart
@@ -109,7 +109,7 @@ class ActivitiesRepository {
 
   /// Deletes multiple activities.
   ///
-  /// Deletes the provided [deleteActivitiesRequest.ids] in a single batch operation.
+  /// Deletes the provided [deleteActivitiesRequest] in a single batch operation.
   ///
   /// Returns a [Result] containing the list of deleted activity ids or an error.
   Future<Result<api.DeleteActivitiesResponse>> deleteActivities({

--- a/packages/stream_feeds/lib/src/state/query/activities_query.dart
+++ b/packages/stream_feeds/lib/src/state/query/activities_query.dart
@@ -35,7 +35,7 @@ class ActivitiesQuery with _$ActivitiesQuery {
   ///
   /// Use [ActivitiesFilterField] for type-safe field references.
   @override
-  final Filter? filter;
+  final Filter<ActivitiesFilterField>? filter;
 
   /// The sorting criteria for this query.
   @override
@@ -57,7 +57,7 @@ class ActivitiesQuery with _$ActivitiesQuery {
 // region Filter
 
 /// Represents a field that can be used in activities filtering.
-extension type const ActivitiesFilterField(String field) implements String {
+extension type const ActivitiesFilterField(String _) implements FilterField {
   /// Filter by the creation timestamp of the activity.
   ///
   /// **Supported operators:** `.equal`, `.greaterThan`, `.lessThan`, `.greaterThanOrEqual`, `.lessThanOrEqual`
@@ -134,7 +134,7 @@ class ActivitiesSort extends Sort<ActivityData> {
 /// This extension type provides specific fields for sorting activity data.
 /// Each field corresponds to a property of the ActivityData model, allowing for flexible
 /// sorting options when querying activities.
-extension type const ActivitiesSortField(SortField<ActivityData> field)
+extension type const ActivitiesSortField(SortField<ActivityData> _)
     implements SortField<ActivityData> {
   /// Sort by the creation timestamp of the activity.
   /// This field allows sorting activities by when they were created (newest/oldest first).

--- a/packages/stream_feeds/lib/src/state/query/activities_query.freezed.dart
+++ b/packages/stream_feeds/lib/src/state/query/activities_query.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$ActivitiesQuery {
-  Filter? get filter;
+  Filter<ActivitiesFilterField>? get filter;
   List<ActivitiesSort>? get sort;
   int? get limit;
   String? get next;
@@ -59,7 +59,7 @@ abstract mixin class $ActivitiesQueryCopyWith<$Res> {
       _$ActivitiesQueryCopyWithImpl;
   @useResult
   $Res call(
-      {Filter? filter,
+      {Filter<ActivitiesFilterField>? filter,
       List<ActivitiesSort>? sort,
       int? limit,
       String? next,
@@ -89,7 +89,7 @@ class _$ActivitiesQueryCopyWithImpl<$Res>
       filter: freezed == filter
           ? _self.filter
           : filter // ignore: cast_nullable_to_non_nullable
-              as Filter?,
+              as Filter<ActivitiesFilterField>?,
       sort: freezed == sort
           ? _self.sort
           : sort // ignore: cast_nullable_to_non_nullable

--- a/packages/stream_feeds/lib/src/state/query/activity_reactions_query.dart
+++ b/packages/stream_feeds/lib/src/state/query/activity_reactions_query.dart
@@ -45,7 +45,7 @@ class ActivityReactionsQuery with _$ActivityReactionsQuery {
   ///
   /// Use [ActivityReactionsFilterField] for type-safe field references.
   @override
-  final Filter? filter;
+  final Filter<ActivityReactionsFilterField>? filter;
 
   /// Array of sorting criteria for this query.
   ///
@@ -80,8 +80,8 @@ class ActivityReactionsQuery with _$ActivityReactionsQuery {
 ///
 /// This extension type provides a type-safe way to specify which field should be used
 /// when creating filters for activity reactions queries.
-extension type const ActivityReactionsFilterField(String field)
-    implements String {
+extension type const ActivityReactionsFilterField(String _)
+    implements FilterField {
   /// Filter by the reaction type (e.g., "like", "love", "angry").
   ///
   /// **Supported operators:** `.equal`, `.in`
@@ -124,8 +124,7 @@ class ActivityReactionsSort extends Sort<FeedsReactionData> {
 /// Defines the fields by which activity reactions can be sorted.
 ///
 /// This extension type provides specific fields for sorting activity reaction data.
-extension type const ActivityReactionsSortField(
-        SortField<FeedsReactionData> field)
+extension type const ActivityReactionsSortField(SortField<FeedsReactionData> _)
     implements SortField<FeedsReactionData> {
   /// Sort by the creation timestamp of the reaction.
   /// This field allows sorting reactions by when they were created (newest/oldest first).

--- a/packages/stream_feeds/lib/src/state/query/activity_reactions_query.freezed.dart
+++ b/packages/stream_feeds/lib/src/state/query/activity_reactions_query.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ActivityReactionsQuery {
   String get activityId;
-  Filter? get filter;
+  Filter<ActivityReactionsFilterField>? get filter;
   List<ActivityReactionsSort>? get sort;
   int? get limit;
   String? get next;
@@ -63,7 +63,7 @@ abstract mixin class $ActivityReactionsQueryCopyWith<$Res> {
   @useResult
   $Res call(
       {String activityId,
-      Filter? filter,
+      Filter<ActivityReactionsFilterField>? filter,
       List<ActivityReactionsSort>? sort,
       int? limit,
       String? next,
@@ -98,7 +98,7 @@ class _$ActivityReactionsQueryCopyWithImpl<$Res>
       filter: freezed == filter
           ? _self.filter
           : filter // ignore: cast_nullable_to_non_nullable
-              as Filter?,
+              as Filter<ActivityReactionsFilterField>?,
       sort: freezed == sort
           ? _self.sort
           : sort // ignore: cast_nullable_to_non_nullable

--- a/packages/stream_feeds/lib/src/state/query/bookmark_folders_query.dart
+++ b/packages/stream_feeds/lib/src/state/query/bookmark_folders_query.dart
@@ -39,7 +39,7 @@ class BookmarkFoldersQuery with _$BookmarkFoldersQuery {
   ///
   /// Use [BookmarkFoldersFilterField] for type-safe field references.
   @override
-  final Filter? filter;
+  final Filter<BookmarkFoldersFilterField>? filter;
 
   /// Array of sorting criteria for this query.
   ///
@@ -69,8 +69,8 @@ class BookmarkFoldersQuery with _$BookmarkFoldersQuery {
 ///
 /// This extension type provides a type-safe way to specify which field should be used
 /// when creating filters for bookmark folders queries.
-extension type const BookmarkFoldersFilterField(String field)
-    implements String {
+extension type const BookmarkFoldersFilterField(String _)
+    implements FilterField {
   /// Filter by the unique identifier of the bookmark folder.
   ///
   /// **Supported operators:** `.equal`, `.in`
@@ -123,8 +123,7 @@ class BookmarkFoldersSort extends Sort<BookmarkFolderData> {
 /// Defines the fields by which bookmark folders can be sorted.
 ///
 /// This extension type provides specific fields for sorting bookmark folder data.
-extension type const BookmarkFoldersSortField(
-        SortField<BookmarkFolderData> field)
+extension type const BookmarkFoldersSortField(SortField<BookmarkFolderData> _)
     implements SortField<BookmarkFolderData> {
   /// Sort by the creation timestamp of the bookmark folder.
   /// This field allows sorting bookmark folders by when they were created (newest/oldest first).

--- a/packages/stream_feeds/lib/src/state/query/bookmark_folders_query.freezed.dart
+++ b/packages/stream_feeds/lib/src/state/query/bookmark_folders_query.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$BookmarkFoldersQuery {
-  Filter? get filter;
+  Filter<BookmarkFoldersFilterField>? get filter;
   List<BookmarkFoldersSort>? get sort;
   int? get limit;
   String? get next;
@@ -59,7 +59,7 @@ abstract mixin class $BookmarkFoldersQueryCopyWith<$Res> {
       _$BookmarkFoldersQueryCopyWithImpl;
   @useResult
   $Res call(
-      {Filter? filter,
+      {Filter<BookmarkFoldersFilterField>? filter,
       List<BookmarkFoldersSort>? sort,
       int? limit,
       String? next,
@@ -89,7 +89,7 @@ class _$BookmarkFoldersQueryCopyWithImpl<$Res>
       filter: freezed == filter
           ? _self.filter
           : filter // ignore: cast_nullable_to_non_nullable
-              as Filter?,
+              as Filter<BookmarkFoldersFilterField>?,
       sort: freezed == sort
           ? _self.sort
           : sort // ignore: cast_nullable_to_non_nullable

--- a/packages/stream_feeds/lib/src/state/query/bookmarks_query.dart
+++ b/packages/stream_feeds/lib/src/state/query/bookmarks_query.dart
@@ -38,7 +38,7 @@ class BookmarksQuery with _$BookmarksQuery {
   ///
   /// Use [BookmarksFilterField] for type-safe field references.
   @override
-  final Filter? filter;
+  final Filter<BookmarksFilterField>? filter;
 
   /// The sorting criteria for this query.
   ///
@@ -73,7 +73,7 @@ class BookmarksQuery with _$BookmarksQuery {
 ///
 /// This extension type provides a type-safe way to specify which field should be used
 /// when creating filters for bookmarks queries.
-extension type const BookmarksFilterField(String field) implements String {
+extension type const BookmarksFilterField(String _) implements FilterField {
   /// Filter by the unique identifier of the activity that was bookmarked.
   ///
   /// **Supported operators:** `.equal`, `.in`
@@ -126,7 +126,7 @@ class BookmarksSort extends Sort<BookmarkData> {
 /// Defines the fields by which bookmarks can be sorted.
 ///
 /// This extension type provides specific fields for sorting bookmark data.
-extension type const BookmarksSortField(SortField<BookmarkData> field)
+extension type const BookmarksSortField(SortField<BookmarkData> _)
     implements SortField<BookmarkData> {
   /// Sort by the creation timestamp of the bookmark.
   /// This field allows sorting bookmarks by when they were created (newest/oldest first).

--- a/packages/stream_feeds/lib/src/state/query/bookmarks_query.freezed.dart
+++ b/packages/stream_feeds/lib/src/state/query/bookmarks_query.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$BookmarksQuery {
-  Filter? get filter;
+  Filter<BookmarksFilterField>? get filter;
   List<BookmarksSort>? get sort;
   int? get limit;
   String? get next;
@@ -59,7 +59,7 @@ abstract mixin class $BookmarksQueryCopyWith<$Res> {
       _$BookmarksQueryCopyWithImpl;
   @useResult
   $Res call(
-      {Filter? filter,
+      {Filter<BookmarksFilterField>? filter,
       List<BookmarksSort>? sort,
       int? limit,
       String? next,
@@ -89,7 +89,7 @@ class _$BookmarksQueryCopyWithImpl<$Res>
       filter: freezed == filter
           ? _self.filter
           : filter // ignore: cast_nullable_to_non_nullable
-              as Filter?,
+              as Filter<BookmarksFilterField>?,
       sort: freezed == sort
           ? _self.sort
           : sort // ignore: cast_nullable_to_non_nullable

--- a/packages/stream_feeds/lib/src/state/query/comment_reactions_query.dart
+++ b/packages/stream_feeds/lib/src/state/query/comment_reactions_query.dart
@@ -48,7 +48,7 @@ class CommentReactionsQuery with _$CommentReactionsQuery {
   ///
   /// Use [CommentReactionsFilterField] for type-safe field references.
   @override
-  final Filter? filter;
+  final Filter<CommentReactionsFilterField>? filter;
 
   /// Array of sorting criteria for this query.
   ///
@@ -78,8 +78,8 @@ class CommentReactionsQuery with _$CommentReactionsQuery {
 ///
 /// This extension type provides a type-safe way to specify which field should be used
 /// when creating filters for comment reactions queries.
-extension type const CommentReactionsFilterField(String field)
-    implements String {
+extension type const CommentReactionsFilterField(String _)
+    implements FilterField {
   /// Filter by the reaction type (e.g., "like", "love", "angry").
   ///
   /// **Supported operators:** `.equal`, `.in`
@@ -122,8 +122,7 @@ class CommentReactionsSort extends Sort<FeedsReactionData> {
 /// Defines the fields by which comment reactions can be sorted.
 ///
 /// This extension type provides specific fields for sorting comment reaction data.
-extension type const CommentReactionsSortField(
-        SortField<FeedsReactionData> field)
+extension type const CommentReactionsSortField(SortField<FeedsReactionData> _)
     implements SortField<FeedsReactionData> {
   /// Sort by the creation timestamp of the reaction.
   /// This field allows sorting reactions by when they were created (newest/oldest first).

--- a/packages/stream_feeds/lib/src/state/query/comment_reactions_query.freezed.dart
+++ b/packages/stream_feeds/lib/src/state/query/comment_reactions_query.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CommentReactionsQuery {
   String get commentId;
-  Filter? get filter;
+  Filter<CommentReactionsFilterField>? get filter;
   List<CommentReactionsSort>? get sort;
   int? get limit;
   String? get next;
@@ -63,7 +63,7 @@ abstract mixin class $CommentReactionsQueryCopyWith<$Res> {
   @useResult
   $Res call(
       {String commentId,
-      Filter? filter,
+      Filter<CommentReactionsFilterField>? filter,
       List<CommentReactionsSort>? sort,
       int? limit,
       String? next,
@@ -98,7 +98,7 @@ class _$CommentReactionsQueryCopyWithImpl<$Res>
       filter: freezed == filter
           ? _self.filter
           : filter // ignore: cast_nullable_to_non_nullable
-              as Filter?,
+              as Filter<CommentReactionsFilterField>?,
       sort: freezed == sort
           ? _self.sort
           : sort // ignore: cast_nullable_to_non_nullable

--- a/packages/stream_feeds/lib/src/state/query/comments_query.dart
+++ b/packages/stream_feeds/lib/src/state/query/comments_query.dart
@@ -38,7 +38,7 @@ class CommentsQuery with _$CommentsQuery {
   ///
   /// Use [CommentsFilterField] for type-safe field references.
   @override
-  final Filter? filter;
+  final Filter<CommentsFilterField>? filter;
 
   /// The sorting strategy for this query.
   ///
@@ -71,7 +71,7 @@ class CommentsQuery with _$CommentsQuery {
 ///
 /// This extension type provides a type-safe way to specify which field should be used
 /// when creating filters for comments queries.
-extension type const CommentsFilterField(String field) implements String {
+extension type const CommentsFilterField(String _) implements FilterField {
   /// Filter by the unique identifier of the comment.
   ///
   /// **Supported operators:** `.equal`, `.in`
@@ -157,7 +157,7 @@ abstract interface class CommentsSortDataFields {
   int get score;
 }
 
-extension type const CommentsSortField(SortField<CommentsSortDataFields> field)
+extension type const CommentsSortField(SortField<CommentsSortDataFields> _)
     implements SortField<CommentsSortDataFields> {
   /// Sort by the score of the comment.
   static final score = CommentsSortField(

--- a/packages/stream_feeds/lib/src/state/query/comments_query.freezed.dart
+++ b/packages/stream_feeds/lib/src/state/query/comments_query.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$CommentsQuery {
-  Filter? get filter;
+  Filter<CommentsFilterField>? get filter;
   CommentsSort? get sort;
   int? get limit;
   String? get next;
@@ -59,7 +59,7 @@ abstract mixin class $CommentsQueryCopyWith<$Res> {
       _$CommentsQueryCopyWithImpl;
   @useResult
   $Res call(
-      {Filter? filter,
+      {Filter<CommentsFilterField>? filter,
       CommentsSort? sort,
       int? limit,
       String? next,
@@ -89,7 +89,7 @@ class _$CommentsQueryCopyWithImpl<$Res>
       filter: freezed == filter
           ? _self.filter
           : filter // ignore: cast_nullable_to_non_nullable
-              as Filter?,
+              as Filter<CommentsFilterField>?,
       sort: freezed == sort
           ? _self.sort
           : sort // ignore: cast_nullable_to_non_nullable

--- a/packages/stream_feeds/lib/src/state/query/feed_query.dart
+++ b/packages/stream_feeds/lib/src/state/query/feed_query.dart
@@ -50,7 +50,7 @@ class FeedQuery with _$FeedQuery {
   ///
   /// Use [ActivitiesFilterField] for type-safe field references.
   @override
-  final Filter? activityFilter;
+  final Filter<ActivitiesFilterField>? activityFilter;
 
   /// The maximum number of activities to retrieve.
   @override

--- a/packages/stream_feeds/lib/src/state/query/feed_query.freezed.dart
+++ b/packages/stream_feeds/lib/src/state/query/feed_query.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$FeedQuery {
   FeedId get fid;
-  Filter? get activityFilter;
+  Filter<ActivitiesFilterField>? get activityFilter;
   int? get activityLimit;
   String? get activityNext;
   String? get activityPrevious;
@@ -99,7 +99,7 @@ abstract mixin class $FeedQueryCopyWith<$Res> {
   @useResult
   $Res call(
       {FeedId fid,
-      Filter? activityFilter,
+      Filter<ActivitiesFilterField>? activityFilter,
       int? activityLimit,
       String? activityNext,
       String? activityPrevious,
@@ -149,7 +149,7 @@ class _$FeedQueryCopyWithImpl<$Res> implements $FeedQueryCopyWith<$Res> {
       activityFilter: freezed == activityFilter
           ? _self.activityFilter
           : activityFilter // ignore: cast_nullable_to_non_nullable
-              as Filter?,
+              as Filter<ActivitiesFilterField>?,
       activityLimit: freezed == activityLimit
           ? _self.activityLimit
           : activityLimit // ignore: cast_nullable_to_non_nullable

--- a/packages/stream_feeds/lib/src/state/query/feeds_query.dart
+++ b/packages/stream_feeds/lib/src/state/query/feeds_query.dart
@@ -37,7 +37,7 @@ class FeedsQuery with _$FeedsQuery {
   ///
   /// Use [FeedsFilterField] for type-safe field references.
   @override
-  final Filter? filter;
+  final Filter<FeedsFilterField>? filter;
 
   /// The sorting criteria for this query.
   @override
@@ -66,7 +66,7 @@ class FeedsQuery with _$FeedsQuery {
 ///
 /// This type provides a type-safe way to specify which field should be used
 /// when creating filters for feeds queries.
-extension type const FeedsFilterField(String field) implements String {
+extension type const FeedsFilterField(String _) implements FilterField {
   /// Filter by the unique identifier of the feed.
   ///
   /// **Supported operators:** `.equal`, `.in`
@@ -189,7 +189,7 @@ class FeedsSort extends Sort<FeedData> {
 ///
 /// Each field corresponds to a property of the [FeedData] model, allowing for
 /// flexible sorting options when querying feeds.
-extension type const FeedsSortField(SortField<FeedData> field)
+extension type const FeedsSortField(SortField<FeedData> _)
     implements SortField<FeedData> {
   /// Sort by the creation timestamp of the feed.
   ///

--- a/packages/stream_feeds/lib/src/state/query/feeds_query.freezed.dart
+++ b/packages/stream_feeds/lib/src/state/query/feeds_query.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$FeedsQuery {
-  Filter? get filter;
+  Filter<FeedsFilterField>? get filter;
   List<FeedsSort>? get sort;
   int? get limit;
   String? get next;
@@ -60,7 +60,7 @@ abstract mixin class $FeedsQueryCopyWith<$Res> {
       _$FeedsQueryCopyWithImpl;
   @useResult
   $Res call(
-      {Filter? filter,
+      {Filter<FeedsFilterField>? filter,
       List<FeedsSort>? sort,
       int? limit,
       String? next,
@@ -91,7 +91,7 @@ class _$FeedsQueryCopyWithImpl<$Res> implements $FeedsQueryCopyWith<$Res> {
       filter: freezed == filter
           ? _self.filter
           : filter // ignore: cast_nullable_to_non_nullable
-              as Filter?,
+              as Filter<FeedsFilterField>?,
       sort: freezed == sort
           ? _self.sort
           : sort // ignore: cast_nullable_to_non_nullable

--- a/packages/stream_feeds/lib/src/state/query/follows_query.dart
+++ b/packages/stream_feeds/lib/src/state/query/follows_query.dart
@@ -43,7 +43,7 @@ class FollowsQuery with _$FollowsQuery {
   ///
   /// Use [FollowsFilterField] for type-safe field references.
   @override
-  final Filter? filter;
+  final Filter<FollowsFilterField>? filter;
 
   /// Array of sorting criteria for this query.
   ///
@@ -82,7 +82,7 @@ class FollowsQuery with _$FollowsQuery {
 ///
 /// This extension type provides a type-safe way to specify which field should be used
 /// when creating filters for follows queries.
-extension type const FollowsFilterField(String field) implements String {
+extension type const FollowsFilterField(String _) implements FilterField {
   /// Filter by the source feed ID (the feed that is following).
   ///
   /// **Supported operators:** `.equal`, `.in`
@@ -130,7 +130,7 @@ class FollowsSort extends Sort<FollowData> {
 /// Defines the fields by which follows can be sorted.
 ///
 /// This extension type provides specific fields for sorting follow data.
-extension type const FollowsSortField(SortField<FollowData> field)
+extension type const FollowsSortField(SortField<FollowData> _)
     implements SortField<FollowData> {
   /// Sort by the creation timestamp of the follow relationship.
   /// This field allows sorting follows by when they were created (newest/oldest first).

--- a/packages/stream_feeds/lib/src/state/query/follows_query.freezed.dart
+++ b/packages/stream_feeds/lib/src/state/query/follows_query.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$FollowsQuery {
-  Filter? get filter;
+  Filter<FollowsFilterField>? get filter;
   List<FollowsSort>? get sort;
   int? get limit;
   String? get next;
@@ -59,7 +59,7 @@ abstract mixin class $FollowsQueryCopyWith<$Res> {
       _$FollowsQueryCopyWithImpl;
   @useResult
   $Res call(
-      {Filter? filter,
+      {Filter<FollowsFilterField>? filter,
       List<FollowsSort>? sort,
       int? limit,
       String? next,
@@ -88,7 +88,7 @@ class _$FollowsQueryCopyWithImpl<$Res> implements $FollowsQueryCopyWith<$Res> {
       filter: freezed == filter
           ? _self.filter
           : filter // ignore: cast_nullable_to_non_nullable
-              as Filter?,
+              as Filter<FollowsFilterField>?,
       sort: freezed == sort
           ? _self.sort
           : sort // ignore: cast_nullable_to_non_nullable

--- a/packages/stream_feeds/lib/src/state/query/members_query.dart
+++ b/packages/stream_feeds/lib/src/state/query/members_query.dart
@@ -46,7 +46,7 @@ class MembersQuery with _$MembersQuery {
   ///
   /// Use [MembersFilterField] for type-safe field references.
   @override
-  final Filter? filter;
+  final Filter<MembersFilterField>? filter;
 
   /// The sorting criteria for this query.
   ///
@@ -81,7 +81,7 @@ class MembersQuery with _$MembersQuery {
 ///
 /// This extension type provides a type-safe way to specify which field should be used
 /// when creating filters for members queries.
-extension type const MembersFilterField(String field) implements String {
+extension type const MembersFilterField(String _) implements FilterField {
   /// Filter by the creation timestamp of the member.
   ///
   /// **Supported operators:** `.equal`, `.greaterThan`, `.lessThan`, `.greaterThanOrEqual`, `.lessThanOrEqual`
@@ -153,7 +153,7 @@ class MembersSort extends Sort<FeedMemberData> {
 /// This extension type provides specific fields for sorting feed member data.
 /// Each field corresponds to a property of the FeedMemberData model, allowing for flexible
 /// sorting options when querying members.
-extension type const MembersSortField(SortField<FeedMemberData> field)
+extension type const MembersSortField(SortField<FeedMemberData> _)
     implements SortField<FeedMemberData> {
   /// Sort by the creation timestamp of the member.
   /// This field allows sorting members by when they were added to the feed (newest/oldest first).

--- a/packages/stream_feeds/lib/src/state/query/members_query.freezed.dart
+++ b/packages/stream_feeds/lib/src/state/query/members_query.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MembersQuery {
   FeedId get fid;
-  Filter? get filter;
+  Filter<MembersFilterField>? get filter;
   List<MembersSort>? get sort;
   int? get limit;
   String? get next;
@@ -62,7 +62,7 @@ abstract mixin class $MembersQueryCopyWith<$Res> {
   @useResult
   $Res call(
       {FeedId fid,
-      Filter? filter,
+      Filter<MembersFilterField>? filter,
       List<MembersSort>? sort,
       int? limit,
       String? next,
@@ -96,7 +96,7 @@ class _$MembersQueryCopyWithImpl<$Res> implements $MembersQueryCopyWith<$Res> {
       filter: freezed == filter
           ? _self.filter
           : filter // ignore: cast_nullable_to_non_nullable
-              as Filter?,
+              as Filter<MembersFilterField>?,
       sort: freezed == sort
           ? _self.sort
           : sort // ignore: cast_nullable_to_non_nullable

--- a/packages/stream_feeds/lib/src/state/query/moderation_configs_query.dart
+++ b/packages/stream_feeds/lib/src/state/query/moderation_configs_query.dart
@@ -39,7 +39,7 @@ class ModerationConfigsQuery with _$ModerationConfigsQuery {
   ///
   /// Use [ModerationConfigsFilterField] for type-safe field references.
   @override
-  final Filter? filter;
+  final Filter<ModerationConfigsFilterField>? filter;
 
   /// Array of sorting criteria for this query.
   ///
@@ -69,8 +69,8 @@ class ModerationConfigsQuery with _$ModerationConfigsQuery {
 ///
 /// This extension type provides a type-safe way to specify which field should be used
 /// when creating filters for moderation configs queries.
-extension type const ModerationConfigsFilterField(String field)
-    implements String {
+extension type const ModerationConfigsFilterField(String _)
+    implements FilterField {
   /// Filter by the unique identifier of the moderation config.
   ///
   /// **Supported operators:** `.equal`, `.in`
@@ -134,7 +134,7 @@ class ModerationConfigsSort extends Sort<ModerationConfigData> {
 /// Each field corresponds to a property of the [ModerationConfigData] model, allowing for
 /// flexible sorting options when querying moderation configs.
 extension type const ModerationConfigsSortField(
-        SortField<ModerationConfigData> field)
+        SortField<ModerationConfigData> _)
     implements SortField<ModerationConfigData> {
   /// Sort by the unique key of the moderation config.
   ///

--- a/packages/stream_feeds/lib/src/state/query/moderation_configs_query.freezed.dart
+++ b/packages/stream_feeds/lib/src/state/query/moderation_configs_query.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$ModerationConfigsQuery {
-  Filter? get filter;
+  Filter<ModerationConfigsFilterField>? get filter;
   List<ModerationConfigsSort>? get sort;
   int? get limit;
   String? get next;
@@ -59,7 +59,7 @@ abstract mixin class $ModerationConfigsQueryCopyWith<$Res> {
       _$ModerationConfigsQueryCopyWithImpl;
   @useResult
   $Res call(
-      {Filter? filter,
+      {Filter<ModerationConfigsFilterField>? filter,
       List<ModerationConfigsSort>? sort,
       int? limit,
       String? next,
@@ -89,7 +89,7 @@ class _$ModerationConfigsQueryCopyWithImpl<$Res>
       filter: freezed == filter
           ? _self.filter
           : filter // ignore: cast_nullable_to_non_nullable
-              as Filter?,
+              as Filter<ModerationConfigsFilterField>?,
       sort: freezed == sort
           ? _self.sort
           : sort // ignore: cast_nullable_to_non_nullable

--- a/packages/stream_feeds/lib/src/state/query/poll_votes_query.dart
+++ b/packages/stream_feeds/lib/src/state/query/poll_votes_query.dart
@@ -51,7 +51,7 @@ class PollVotesQuery with _$PollVotesQuery {
   ///
   /// Use [PollVotesFilterField] for type-safe field references.
   @override
-  final Filter? filter;
+  final Filter<PollVotesFilterField>? filter;
 
   /// Array of sorting criteria for this query.
   ///
@@ -81,7 +81,7 @@ class PollVotesQuery with _$PollVotesQuery {
 ///
 /// This extension type provides a type-safe way to specify which field should be used
 /// when creating filters for poll votes queries.
-extension type const PollVotesFilterField(String field) implements String {
+extension type const PollVotesFilterField(String _) implements FilterField {
   /// Filter by the creation timestamp of the poll vote.
   ///
   /// **Supported operators:** `.equal`, `.greaterThan`, `.lessThan`, `.greaterThanOrEqual`, `.lessThanOrEqual`
@@ -144,7 +144,7 @@ class PollVotesSort extends Sort<PollVoteData> {
 /// Defines the fields by which poll votes can be sorted.
 ///
 /// This extension type provides specific fields for sorting poll vote data.
-extension type const PollVotesSortField(SortField<PollVoteData> field)
+extension type const PollVotesSortField(SortField<PollVoteData> _)
     implements SortField<PollVoteData> {
   /// Sort by the answer text of the poll option.
   /// This field allows sorting poll votes by the text content of the selected option.

--- a/packages/stream_feeds/lib/src/state/query/poll_votes_query.freezed.dart
+++ b/packages/stream_feeds/lib/src/state/query/poll_votes_query.freezed.dart
@@ -17,7 +17,7 @@ T _$identity<T>(T value) => value;
 mixin _$PollVotesQuery {
   String get pollId;
   String? get userId;
-  Filter? get filter;
+  Filter<PollVotesFilterField>? get filter;
   List<PollVotesSort>? get sort;
   int? get limit;
   String? get next;
@@ -65,7 +65,7 @@ abstract mixin class $PollVotesQueryCopyWith<$Res> {
   $Res call(
       {String pollId,
       String? userId,
-      Filter? filter,
+      Filter<PollVotesFilterField>? filter,
       List<PollVotesSort>? sort,
       int? limit,
       String? next,
@@ -105,7 +105,7 @@ class _$PollVotesQueryCopyWithImpl<$Res>
       filter: freezed == filter
           ? _self.filter
           : filter // ignore: cast_nullable_to_non_nullable
-              as Filter?,
+              as Filter<PollVotesFilterField>?,
       sort: freezed == sort
           ? _self.sort
           : sort // ignore: cast_nullable_to_non_nullable

--- a/packages/stream_feeds/lib/src/state/query/polls_query.dart
+++ b/packages/stream_feeds/lib/src/state/query/polls_query.dart
@@ -40,7 +40,7 @@ class PollsQuery with _$PollsQuery {
   ///
   /// Use [PollsFilterField] for type-safe field references.
   @override
-  final Filter? filter;
+  final Filter<PollsFilterField>? filter;
 
   /// Array of sorting criteria for this query.
   ///
@@ -70,7 +70,7 @@ class PollsQuery with _$PollsQuery {
 ///
 /// This extension type provides a type-safe way to specify which field should be used
 /// when creating filters for polls queries.
-extension type const PollsFilterField(String field) implements String {
+extension type const PollsFilterField(String _) implements FilterField {
   /// Filter by whether the poll allows answers.
   ///
   /// **Supported operators:** `.equal`
@@ -149,7 +149,7 @@ class PollsSort extends Sort<PollData> {
 /// Defines the fields by which polls can be sorted.
 ///
 /// This extension type provides specific fields for sorting poll data.
-extension type const PollsSortField(SortField<PollData> field)
+extension type const PollsSortField(SortField<PollData> _)
     implements SortField<PollData> {
   /// Sort by the creation timestamp of the poll.
   /// This field allows sorting polls by when they were created (newest/oldest first).

--- a/packages/stream_feeds/lib/src/state/query/polls_query.freezed.dart
+++ b/packages/stream_feeds/lib/src/state/query/polls_query.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$PollsQuery {
-  Filter? get filter;
+  Filter<PollsFilterField>? get filter;
   List<PollsSort>? get sort;
   int? get limit;
   String? get next;
@@ -58,7 +58,7 @@ abstract mixin class $PollsQueryCopyWith<$Res> {
       _$PollsQueryCopyWithImpl;
   @useResult
   $Res call(
-      {Filter? filter,
+      {Filter<PollsFilterField>? filter,
       List<PollsSort>? sort,
       int? limit,
       String? next,
@@ -87,7 +87,7 @@ class _$PollsQueryCopyWithImpl<$Res> implements $PollsQueryCopyWith<$Res> {
       filter: freezed == filter
           ? _self.filter
           : filter // ignore: cast_nullable_to_non_nullable
-              as Filter?,
+              as Filter<PollsFilterField>?,
       sort: freezed == sort
           ? _self.sort
           : sort // ignore: cast_nullable_to_non_nullable

--- a/packages/stream_feeds/lib/src/utils/filter.dart
+++ b/packages/stream_feeds/lib/src/utils/filter.dart
@@ -3,5 +3,5 @@ import 'package:stream_core/stream_core.dart';
 /// Extension for converting a [Filter] instance to a request format.
 extension FilterRequestExtension on Filter {
   /// Converts this [Filter] instance to a request format suitable for API calls.
-  Map<String, Object> toRequest() => toJson();
+  Map<String, Object?> toRequest() => toJson();
 }

--- a/packages/stream_feeds/lib/src/ws/events/events.freezed.dart
+++ b/packages/stream_feeds/lib/src/ws/events/events.freezed.dart
@@ -36,7 +36,6 @@ mixin _$HealthCheckEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is HealthCheckEvent &&
-            super == other &&
             (identical(other.cid, cid) || other.cid == cid) &&
             (identical(other.connectionId, connectionId) ||
                 other.connectionId == connectionId) &&
@@ -50,16 +49,8 @@ mixin _$HealthCheckEvent {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      super.hashCode,
-      cid,
-      connectionId,
-      createdAt,
-      const DeepCollectionEquality().hash(custom),
-      me,
-      receivedAt,
-      type);
+  int get hashCode => Object.hash(runtimeType, cid, connectionId, createdAt,
+      const DeepCollectionEquality().hash(custom), me, receivedAt, type);
 
   @override
   String toString() {
@@ -157,7 +148,6 @@ mixin _$ConnectedEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ConnectedEvent &&
-            super == other &&
             (identical(other.connectionId, connectionId) ||
                 other.connectionId == connectionId) &&
             (identical(other.createdAt, createdAt) ||
@@ -167,8 +157,8 @@ mixin _$ConnectedEvent {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, super.hashCode, connectionId, createdAt, me, type);
+  int get hashCode =>
+      Object.hash(runtimeType, connectionId, createdAt, me, type);
 
   @override
   String toString() {
@@ -248,7 +238,6 @@ mixin _$ConnectionErrorEvent {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is ConnectionErrorEvent &&
-            super == other &&
             (identical(other.connectionId, connectionId) ||
                 other.connectionId == connectionId) &&
             (identical(other.createdAt, createdAt) ||
@@ -258,8 +247,8 @@ mixin _$ConnectionErrorEvent {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, super.hashCode, connectionId, createdAt, error, type);
+  int get hashCode =>
+      Object.hash(runtimeType, connectionId, createdAt, error, type);
 
   @override
   String toString() {

--- a/packages/stream_feeds/pubspec.yaml
+++ b/packages/stream_feeds/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   stream_core:
     git:
       url: https://github.com/GetStream/stream-core-flutter.git
-      ref: 5acdcb8e378548372f7dbb6326c518edcf832d10
+      ref: 280b1045e39388668fd060439259831611b51b5a
       path: packages/stream_core
   uuid: ^4.5.1
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -471,8 +471,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/stream_core"
-      ref: "5acdcb8e378548372f7dbb6326c518edcf832d10"
-      resolved-ref: "5acdcb8e378548372f7dbb6326c518edcf832d10"
+      ref: "280b1045e39388668fd060439259831611b51b5a"
+      resolved-ref: "280b1045e39388668fd060439259831611b51b5a"
       url: "https://github.com/GetStream/stream-core-flutter.git"
     source: git
     version: "0.0.1"

--- a/sample_app/lib/navigation/app_router.dart
+++ b/sample_app/lib/navigation/app_router.dart
@@ -44,4 +44,3 @@ class AppRouter extends RootStackRouter {
     ];
   }
 }
-

--- a/sample_app/lib/navigation/guards/auth_guard.dart
+++ b/sample_app/lib/navigation/guards/auth_guard.dart
@@ -1,5 +1,4 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter/foundation.dart';
 import 'package:injectable/injectable.dart';
 
 import '../../app/content/auth_controller.dart';

--- a/sample_app/lib/screens/user_feed/user_feed_screen.dart
+++ b/sample_app/lib/screens/user_feed/user_feed_screen.dart
@@ -227,7 +227,10 @@ class _UserFeedScreenState extends State<UserFeedScreen> {
   }
 
   void _onRepostClick(
-      BuildContext context, ActivityData activity, String? message) {
+    BuildContext context,
+    ActivityData activity,
+    String? message,
+  ) {
     feed.repost(activityId: activity.id, text: message);
   }
 

--- a/sample_app/lib/screens/user_feed/widgets/user_profile_view.dart
+++ b/sample_app/lib/screens/user_feed/widgets/user_profile_view.dart
@@ -59,8 +59,10 @@ class _UserProfileViewState extends State<UserProfileView> {
             Container(
               alignment: Alignment.center,
               padding: const EdgeInsets.all(16),
-              child: Text('User Profile',
-                  style: context.appTextStyles.headlineBold),
+              child: Text(
+                'User Profile',
+                style: context.appTextStyles.headlineBold,
+              ),
             ),
             ProfileItem.text(
               title: 'Feed members',


### PR DESCRIPTION
This commit introduces type-safe filter fields across various query types by parameterizing the `Filter` class with specific `FilterField` extension types.

Key changes:

- **Parameterized `Filter`:** The `Filter` class is now generic `Filter<T extends FilterField>`, ensuring that filters are constructed with valid fields for the specific query type.
- **`FilterField` interface:** A new `FilterField` extension type acts as a base for all specific filter field types (e.g., `ActivitiesFilterField`, `FeedsFilterField`).
- **Updated Query Classes:** All query classes (e.g., `ActivitiesQuery`, `FeedsQuery`, `CommentsQuery`, etc.) now use the parameterized `Filter` with their respective `FilterField` types. This provides compile-time safety for filter field names.
- **Filter Field Extension Types:** Existing string-based filter field constants are now extension types implementing `FilterField`. This maintains compatibility while enabling type safety.
- **`FilterRequestExtension`:** The `toRequest()` method in `FilterRequestExtension` now returns `Map<String, Object?>` to reflect that filter values can be null.
- **Code Snippet Updates:** Documentation code snippets have been updated to reflect the new type-safe filter field usage.
- **Dependency Update:** `stream_core` dependency has been updated to `280b104`.

This refactoring enhances code maintainability and reduces the likelihood of runtime errors caused by incorrect filter field names.
