### PR TITLE
feat(samples): add notification feed and mark as read/seen

### DIFF
--- a/packages/stream_feeds/lib/src/models.dart
+++ b/packages/stream_feeds/lib/src/models.dart
@@ -1,9 +1,12 @@
 export 'models/activity_data.dart';
+export 'models/aggregated_activity_data.dart';
 export 'models/feed_data.dart';
 export 'models/feed_id.dart';
 export 'models/feed_input_data.dart';
+export 'models/feed_member_data.dart';
 export 'models/feed_member_request_data.dart';
 export 'models/feeds_config.dart';
+export 'models/follow_data.dart';
 export 'models/poll_data.dart';
 export 'models/request/activity_add_comment_request.dart'
     show ActivityAddCommentRequest;

--- a/packages/stream_feeds/lib/src/models/mark_activity_data.dart
+++ b/packages/stream_feeds/lib/src/models/mark_activity_data.dart
@@ -45,6 +45,39 @@ class MarkActivityData with _$MarkActivityData {
   final List<String>? markWatched;
 }
 
+extension MarkActivityDataHandler<R> on MarkActivityData {
+  R handle({
+    R Function()? markAllRead,
+    R Function()? markAllSeen,
+    R Function(Set<String> read)? markRead,
+    R Function(Set<String> seen)? markSeen,
+    R Function(Set<String> watched)? markWatched,
+    required R Function(MarkActivityData data) orElse,
+  }) {
+    if (this.markAllRead case true) {
+      return markAllRead?.call() ?? orElse(this);
+    }
+
+    if (this.markAllSeen case true) {
+      return markAllSeen?.call() ?? orElse(this);
+    }
+
+    if (this.markRead case final read?) {
+      return markRead?.call(read.toSet()) ?? orElse(this);
+    }
+
+    if (this.markSeen case final seen?) {
+      return markSeen?.call(seen.toSet()) ?? orElse(this);
+    }
+
+    if (this.markWatched case final watched?) {
+      return markWatched?.call(watched.toSet()) ?? orElse(this);
+    }
+
+    return orElse(this);
+  }
+}
+
 /// Extension function to convert an [ActivityMarkEvent] to a [MarkActivityData] model.
 extension ActivityMarkEventMapper on ActivityMarkEvent {
   /// Converts this API activity mark event to a domain [MarkActivityData] instance.

--- a/packages/stream_feeds/lib/src/repository/feeds_repository.dart
+++ b/packages/stream_feeds/lib/src/repository/feeds_repository.dart
@@ -1,8 +1,10 @@
+import 'package:collection/collection.dart';
 import 'package:stream_core/stream_core.dart';
 
 import '../generated/api/api.dart' as api;
 import '../models/activity_data.dart';
 import '../models/activity_pin_data.dart';
+import '../models/aggregated_activity_data.dart';
 import '../models/feed_data.dart';
 import '../models/feed_id.dart';
 import '../models/feed_member_data.dart';
@@ -54,7 +56,9 @@ class FeedsRepository {
 
       return GetOrCreateFeedData(
         activities: PaginationResult(
-          items: response.activities.map((a) => a.toModel()).toList(),
+          items: response.activities
+              .map((a) => a.toModel())
+              .sorted(ActivitiesSort.defaultSort.compare),
           pagination: PaginationData(
             next: response.next,
             previous: response.prev,
@@ -78,6 +82,9 @@ class FeedsRepository {
         ownCapabilities: response.ownCapabilities,
         pinnedActivities:
             response.pinnedActivities.map((a) => a.toModel()).toList(),
+        aggregatedActivities:
+            response.aggregatedActivities.map((a) => a.toModel()).toList(),
+        notificationStatus: response.notificationStatus,
       );
     });
   }

--- a/sample_app/lib/screens/user_feed/notification/notification_feed.dart
+++ b/sample_app/lib/screens/user_feed/notification/notification_feed.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_state_notifier/flutter_state_notifier.dart';
+import 'package:stream_feeds/stream_feeds.dart';
+
+import '../../../theme/extensions/theme_extensions.dart';
+import 'notification_item.dart';
+
+class NotificationFeed extends StatelessWidget {
+  const NotificationFeed({
+    super.key,
+    required this.notificationFeed,
+    this.scrollController,
+  });
+
+  final Feed notificationFeed;
+  final ScrollController? scrollController;
+
+  @override
+  Widget build(BuildContext context) {
+    return StateNotifierBuilder(
+      stateNotifier: notificationFeed.notifier,
+      builder: (context, state, child) {
+        final activities = state.aggregatedActivities;
+        final canLoadMore = state.canLoadMoreActivities;
+        final notificationStatus = state.notificationStatus;
+
+        if (notificationStatus?.unseen case final unseen? when unseen > 0) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (context.mounted) _onMarkAllSeen();
+          });
+        }
+
+        return Column(
+          children: [
+            _buildHeader(
+              context,
+              activities,
+              notificationStatus,
+            ),
+            Expanded(
+              child: _buildNotificationContent(
+                context,
+                activities,
+                canLoadMore,
+                notificationStatus,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildHeader(
+    BuildContext context,
+    List<AggregatedActivityData> activities,
+    NotificationStatusResponse? notificationStatus,
+  ) {
+    final hasUnreadNotifications = _hasUnreadNotifications(
+      activities,
+      notificationStatus,
+    );
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: 20,
+        vertical: 16,
+      ),
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(
+            color: context.appColors.borders,
+          ),
+        ),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            'Notifications',
+            style: context.appTextStyles.headlineBold,
+          ),
+          if (hasUnreadNotifications)
+            OutlinedButton.icon(
+              onPressed: _onMarkAllRead,
+              icon: const Icon(Icons.done_all),
+              label: const Text('Mark read'),
+              style: OutlinedButton.styleFrom(
+                minimumSize: Size.zero,
+                iconColor: context.appColors.accentPrimary,
+                foregroundColor: context.appColors.accentPrimary,
+                side: BorderSide(color: context.appColors.accentPrimary),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 6,
+                ),
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                textStyle: context.appTextStyles.footnoteBold,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNotificationContent(
+    BuildContext context,
+    List<AggregatedActivityData> activities,
+    bool canLoadMore,
+    NotificationStatusResponse? notificationStatus,
+  ) {
+    if (activities.isEmpty) return const EmptyNotifications();
+
+    return RefreshIndicator(
+      onRefresh: notificationFeed.getOrCreate,
+      child: ListView.separated(
+        controller: scrollController,
+        itemCount: activities.length + 1,
+        separatorBuilder: (context, index) => Divider(
+          height: 1,
+          color: context.appColors.borders,
+        ),
+        itemBuilder: (context, index) {
+          if (index == activities.length) {
+            return switch (canLoadMore) {
+              true => TextButton(
+                  onPressed: notificationFeed.queryMoreActivities,
+                  child: const Text('Load more...'),
+                ),
+              false => const Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Center(
+                    child: Text('End of notifications'),
+                  ),
+                ),
+            };
+          }
+
+          final activity = activities[index];
+          final read = notificationStatus?.readActivities;
+          final isUnread = read?.contains(activity.group) != true;
+
+          return Padding(
+            padding: const EdgeInsets.all(8),
+            child: NotificationItem(
+              activity: activity,
+              isUnread: isUnread,
+              onTap: () => _onNotificationTap(activity),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  bool _hasUnreadNotifications(
+    List<AggregatedActivityData> activities,
+    NotificationStatusResponse? notificationStatus,
+  ) {
+    if (activities.isEmpty) return false;
+
+    final read = notificationStatus?.readActivities ?? [];
+    return activities.any((activity) => !read.contains(activity.group));
+  }
+
+  Future<void> _onMarkAllRead() async {
+    await notificationFeed.markActivity(
+      request: const MarkActivityRequest(markAllRead: true),
+    );
+  }
+
+  Future<void> _onMarkAllSeen() async {
+    await notificationFeed.markActivity(
+      request: const MarkActivityRequest(markAllSeen: true),
+    );
+  }
+
+  Future<void> _onNotificationTap(AggregatedActivityData activity) async {
+    await notificationFeed.markActivity(
+      request: MarkActivityRequest(markRead: [activity.group]),
+    );
+  }
+}
+
+class EmptyNotifications extends StatelessWidget {
+  const EmptyNotifications({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.notifications_none_rounded,
+            size: 64,
+            color: context.appColors.textLowEmphasis,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'No notifications yet',
+            style: context.appTextStyles.headline.copyWith(
+              color: context.appColors.textLowEmphasis,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            "When you get notifications, they'll appear here",
+            style: context.appTextStyles.body.copyWith(
+              color: context.appColors.textLowEmphasis,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/sample_app/lib/screens/user_feed/notification/notification_item.dart
+++ b/sample_app/lib/screens/user_feed/notification/notification_item.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:stream_feeds/stream_feeds.dart';
+
+import '../../../theme/extensions/theme_extensions.dart';
+import '../../../utils/date_time_extensions.dart';
+
+class NotificationItem extends StatelessWidget {
+  const NotificationItem({
+    super.key,
+    required this.activity,
+    required this.isUnread,
+    this.onTap,
+  });
+
+  final AggregatedActivityData activity;
+  final bool isUnread;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: [
+            _buildNotificationIcon(context),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildNotificationText(context),
+                  const SizedBox(height: 4),
+                  Text(
+                    activity.updatedAt.displayRelativeTime,
+                    style: context.appTextStyles.footnote.copyWith(
+                      color: context.appColors.textLowEmphasis,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (isUnread)
+              Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(
+                  color: context.appColors.accentPrimary,
+                  shape: BoxShape.circle,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNotificationIcon(BuildContext context) {
+    final notificationType = activity.notificationType;
+
+    final iconData = switch (notificationType) {
+      'follow' => Icons.person_add,
+      'comment' => Icons.chat_bubble_outline,
+      'reaction' => Icons.favorite_outline,
+      'comment_reaction' => Icons.thumb_up,
+      'mention' => Icons.alternate_email,
+      _ => Icons.notifications_outlined,
+    };
+
+    final iconColor = switch (notificationType) {
+      'reaction' || 'comment_reaction' => context.appColors.accentError,
+      _ => context.appColors.accentPrimary,
+    };
+
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        color: iconColor.withValues(alpha: 0.1),
+        shape: BoxShape.circle,
+      ),
+      child: Icon(
+        iconData,
+        color: iconColor,
+        size: 20,
+      ),
+    );
+  }
+
+  Widget _buildNotificationText(BuildContext context) {
+    final notificationText = activity.displayText;
+
+    return Text(
+      notificationText,
+      style: context.appTextStyles.body.copyWith(
+        color: context.appColors.textHighEmphasis,
+      ),
+    );
+  }
+}
+
+extension on AggregatedActivityData {
+  String get displayText {
+    if (activities.isEmpty) return '';
+
+    final firstUser = firstUserName;
+    final otherUsers = userCount == 2 ? 'other' : 'others';
+    final actionText = activities.first.type.let(
+      _displayTextForAggregationType,
+    );
+
+    if (userCount > 1) {
+      return '$firstUser and ${userCount - 1} $otherUsers $actionText';
+    }
+
+    return '$firstUser $actionText';
+  }
+
+  String get firstUserName => activities.lastOrNull?.user.name ?? 'Someone';
+
+  String get notificationType => activities.firstOrNull?.type ?? group;
+}
+
+String _displayTextForAggregationType(String type) {
+  return switch (type) {
+    'follow' => 'followed you',
+    'comment' => 'commented on your activity',
+    'reaction' => 'reacted on your activity',
+    'comment_reaction' => 'reacted on your comment',
+    'mention' => 'mentioned you',
+    _ => 'interacted with your activity',
+  };
+}

--- a/sample_app/lib/screens/user_feed/widgets/activity_content.dart
+++ b/sample_app/lib/screens/user_feed/widgets/activity_content.dart
@@ -167,9 +167,6 @@ class _UserActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    //val heartsCount = activity.reactionGroups["heart"]?.count ?: 0
-    //         val hasOwnHeart = activity.ownReactions.any { it.type == "heart" }
-
     final heartsCount = data.reactionGroups['heart']?.count ?? 0;
     final hasOwnHeart = data.ownReactions.any((it) => it.type == 'heart');
 
@@ -185,9 +182,10 @@ class _UserActions extends StatelessWidget {
         ),
         ActionButton(
           icon: Icon(
-            hasOwnHeart
-                ? Icons.favorite_rounded
-                : Icons.favorite_outline_rounded,
+            switch (hasOwnHeart) {
+              true => Icons.favorite_rounded,
+              false => Icons.favorite_outline_rounded,
+            },
           ),
           count: heartsCount,
           color: hasOwnHeart ? context.appColors.accentError : null,
@@ -200,9 +198,10 @@ class _UserActions extends StatelessWidget {
         ),
         ActionButton(
           icon: Icon(
-            hasOwnBookmark
-                ? Icons.bookmark_rounded
-                : Icons.bookmark_outline_rounded,
+            switch (hasOwnBookmark) {
+              true => Icons.bookmark_rounded,
+              false => Icons.bookmark_outline_rounded,
+            },
           ),
           count: data.bookmarkCount,
           color: hasOwnBookmark ? context.appColors.accentPrimary : null,

--- a/sample_app/lib/theme/schemes/app_text_theme.dart
+++ b/sample_app/lib/theme/schemes/app_text_theme.dart
@@ -66,7 +66,7 @@ class AppTextTheme {
       ),
       bodyBold: TextStyle(
         fontSize: 14,
-        fontWeight: FontWeight.w700,
+        fontWeight: FontWeight.w500,
         color: textColor,
       ),
       footnote: TextStyle(

--- a/sample_app/lib/widgets/action_button.dart
+++ b/sample_app/lib/widgets/action_button.dart
@@ -25,7 +25,6 @@ class ActionButton extends StatelessWidget {
     this.disabledColor,
     this.iconSize = kDefaultActionButtonIconSize,
     this.padding = const EdgeInsets.all(kDefaultActionButtonPadding),
-    this.showCountWhenZero = false,
   });
 
   /// The icon to display inside the button.
@@ -57,45 +56,21 @@ class ActionButton extends StatelessWidget {
   /// Defaults to EdgeInsets.all(8.0).
   final EdgeInsetsGeometry padding;
 
-  /// Whether to show the count even when it's zero.
-  ///
-  /// Defaults to false.
-  final bool showCountWhenZero;
-
   @override
   Widget build(BuildContext context) {
-    final shouldShowCount = showCountWhenZero || count > 0;
-
-    if (shouldShowCount) {
-      return TextButton.icon(
-        onPressed: onTap,
-        icon: icon,
-        label: Text(
-          count.toString(),
-          style: context.appTextStyles.footnote,
-        ),
-        style: TextButton.styleFrom(
-          foregroundColor: color,
-          iconColor: color,
-          disabledForegroundColor: disabledColor,
-          disabledIconColor: disabledColor,
-          iconSize: iconSize,
-          padding: padding,
-          minimumSize: Size.zero,
-          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        ),
-      );
-    }
-
-    return IconButton(
-      onPressed: onTap,
+    return TextButton.icon(
       icon: icon,
-      color: color,
-      disabledColor: disabledColor,
-      iconSize: iconSize,
-      padding: padding,
-      style: IconButton.styleFrom(
+      onPressed: onTap,
+      label: Text(count.toString()),
+      style: TextButton.styleFrom(
+        foregroundColor: color,
+        iconColor: color,
+        disabledForegroundColor: disabledColor,
+        disabledIconColor: disabledColor,
+        iconSize: iconSize,
+        padding: padding,
         minimumSize: Size.zero,
+        textStyle: context.appTextStyles.footnote,
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
       ),
     );


### PR DESCRIPTION
This commit introduces a notification feed to the sample app and implements the ability to mark notifications as read or seen.