### PR TITLE
feat(samples): update demo users and api key

### DIFF
--- a/sample_app/lib/config/demo_app_config.dart
+++ b/sample_app/lib/config/demo_app_config.dart
@@ -8,7 +8,7 @@ enum DemoAppConfig {
     tokenForUser: _localhostTokenForUser,
   ),
   production(
-    apiKey: 'fa5xpkvxrdw4',
+    apiKey: 'mka5cua4vrjt',
     tokenForUser: _productionTokenForUser,
   );
 
@@ -24,8 +24,12 @@ enum DemoAppConfig {
 
   static String _stagingTokenForUser(String userId) {
     switch (userId) {
-      case 'luke_skywalker':
-        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIifQ.hZ59SWtp_zLKVV9ShkqkTsCGi_jdPHly7XNCf5T_Ev0';
+      case 'sahil':
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoic2FoaWwifQ.JflZ12wPiluwji_BlVhQRN4_Z72zXs0plopWmKl49DE';
+      case 'rene':
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicmVuZSJ9.NGuadPFKoAW_EAfZu_9chah3hxc2sgBuzaw2Ej6WKkY';
+      case 'maciej':
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibWFjaWVqIn0.cmHSUCT0JD3s439uLRsJOmwbBNM1N5miIgE1zfHo59Y';
       case 'martin':
         return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibWFydGluIn0.ZDox0RWqhKhhK2lrbUVJvf8Zd9PVA_NX5dGMVC6mcSg';
       case 'tommaso':
@@ -45,8 +49,12 @@ enum DemoAppConfig {
 
   static String _localhostTokenForUser(String userId) {
     switch (userId) {
-      case 'luke_skywalker':
-        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIifQ.hZ59SWtp_zLKVV9ShkqkTsCGi_jdPHly7XNCf5T_Ev0';
+      case 'sahil':
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoic2FoaWwifQ.xE7RTWiwafZhLuY3XeOLgvz1D4hPV3pvsgKP7vI1fak';
+      case 'rene':
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicmVuZSJ9.mUH3XG8wOYnnyHAaykIZT6B7ShH9kAJ8uHwZZw_TwAw';
+      case 'maciej':
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibWFjaWVqIn0.FK85ui3RWAmap_Mm1i8-qnQUnfQ5AQmnY303zkzT7O4';
       case 'martin':
         return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibWFydGluIn0.-8mL49OqMdlvzXR_1IgYboVXXuXFc04r0EvYgko-X8I';
       case 'tommaso':
@@ -66,20 +74,24 @@ enum DemoAppConfig {
 
   static String _productionTokenForUser(String userId) {
     switch (userId) {
-      case 'luke_skywalker':
-        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIifQ.zuAJWZfZWPFJYYItt1QQnUl2IlTq6PcBPStrcD_U91A';
+      case 'sahil':
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoic2FoaWwifQ.UtwB0-iOGeLvibIRyAhRJ3gQU3_H7DzymqVuNU9Ihik';
+      case 'rene':
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicmVuZSJ9.x_Oj7FSgu-S46lxBbqrN4vBw-K3UV6b2sh7_Rw2eDVc';
+      case 'maciej':
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibWFjaWVqIn0.pLzlhE10_BaiEB_Mc-Bky-Sa74rGIcjppQ2TUOhrvik';
       case 'martin':
-        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibWFydGluIn0.w4IhPDZXHTnY_JTZqT5f75TpZ-Qq5gFgXHM8-mkjYjg';
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibWFydGluIn0.NPmmE-noa4FXDasTCY4GE0Sh6OiyR8rkci5gzlZZMzA';
       case 'tommaso':
-        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidG9tbWFzbyJ9.3sl5XZMbSVvBfJhoT6islSfNMlPU46uZeKr_UCFESWY';
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidG9tbWFzbyJ9.1vLULalxFvM2BDVtHXzz9xkBz8uMI4pxxb79XOMi7fE';
       case 'thierry':
-        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGhpZXJyeSJ9.2vI4zX2WB6zlSZQdAwLqwRo8RRTPMDKLQF3lNJTiIG8';
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGhpZXJyeSJ9.WT_Ov6cl6qS_JniW9iexZOQmfG4R3PDG9aHUMTAIwOY';
       case 'marcelo':
-        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibWFyY2VsbyJ9.JGUi40Ew7SyrGab1AAr0pIXPKfqVMTiyPJPCs8EFaVY';
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibWFyY2VsbyJ9.lyOWBAamtPNPbroA46XeA2F9pOAMauGxCZ0UxI1UbBk';
       case 'kanat':
-        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoia2FuYXQifQ.J7N5-RSAStR8UF3g7ce-fSSgBSLTszr5St3MwFBujfs';
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoia2FuYXQifQ.AB7zclWiWKui6sMy7us2Scnw96ket2mizlIVtwKfx8M';
       case 'toomas':
-        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidG9vbWFzIn0.JOSpmeEbwIdVu1SoT7y4dZknkbQE_fEDQn5mac9yzU0';
+        return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidG9vbWFzIn0.FIU8F4420qK8tqRQ9XnFoN-Zg8_JNr-SyWpxY12-A-U';
       default:
         return '';
     }

--- a/sample_app/lib/core/models/user_credentials.dart
+++ b/sample_app/lib/core/models/user_credentials.dart
@@ -21,22 +21,38 @@ class UserCredentials {
 
   // region Individual user credentials
 
-  static final luke = UserCredentials(
+  static final sahil = UserCredentials(
     user: const User(
-      id: 'luke_skywalker',
-      name: 'Luke Skywalker',
-      image:
-          'https://vignette.wikia.nocookie.net/starwars/images/2/20/LukeTLJ.jpg',
+      id: 'sahil',
+      name: 'Sahil Kumar',
+      image: 'https://avatars.githubusercontent.com/u/25670178',
     ),
-    token: _tokenForUser('luke_skywalker'),
+    token: _tokenForUser('sahil'),
+  );
+
+  static final rene = UserCredentials(
+    user: const User(
+      id: 'rene',
+      name: 'Rene Floor',
+      image: 'https://avatars.githubusercontent.com/u/15101411',
+    ),
+    token: _tokenForUser('rene'),
+  );
+
+  static final maciej = UserCredentials(
+    user: const User(
+      id: 'maciej',
+      name: 'Maciej Brażewicz',
+      image: 'https://avatars.githubusercontent.com/u/5622717',
+    ),
+    token: _tokenForUser('maciej'),
   );
 
   static final martin = UserCredentials(
     user: const User(
       id: 'martin',
-      name: 'Martin',
-      image:
-          'https://getstream.io/static/2796a305dd07651fcceb4721a94f4505/802d2/martin-mitrevski.webp',
+      name: 'Martin Mitrevski',
+      image: 'https://avatars.githubusercontent.com/u/2971717',
     ),
     token: _tokenForUser('martin'),
   );
@@ -44,9 +60,8 @@ class UserCredentials {
   static final tommaso = UserCredentials(
     user: const User(
       id: 'tommaso',
-      name: 'Tommaso',
-      image:
-          'https://getstream.io/static/712bb5c0bd5ed8d3fa6e5842f6cfbeed/c59de/tommaso.webp',
+      name: 'Tommaso Barbugli',
+      image: 'https://avatars.githubusercontent.com/u/88735',
     ),
     token: _tokenForUser('tommaso'),
   );
@@ -54,9 +69,8 @@ class UserCredentials {
   static final thierry = UserCredentials(
     user: const User(
       id: 'thierry',
-      name: 'Thierry',
-      image:
-          'https://getstream.io/static/237f45f28690696ad8fff92726f45106/c59de/thierry.webp',
+      name: 'Thierry Schellenbach',
+      image: 'https://avatars.githubusercontent.com/u/265409',
     ),
     token: _tokenForUser('thierry'),
   );
@@ -64,20 +78,27 @@ class UserCredentials {
   static final marcelo = UserCredentials(
     user: const User(
       id: 'marcelo',
-      name: 'Marcelo',
-      image:
-          'https://getstream.io/static/aaf5fb17dcfd0a3dd885f62bd21b325a/802d2/marcelo-pires.webp',
+      name: 'Marcelo Pires',
+      image: 'https://avatars.githubusercontent.com/u/916501',
     ),
     token: _tokenForUser('marcelo'),
   );
 
   static final kanat = UserCredentials(
-    user: const User(id: 'kanat', name: 'Kanat'),
+    user: const User(
+      id: 'kanat',
+      name: 'Kanat Kiialbaev',
+      image: 'https://avatars.githubusercontent.com/u/1286516',
+    ),
     token: _tokenForUser('kanat'),
   );
 
   static final toomas = UserCredentials(
-    user: const User(id: 'toomas', name: 'Toomas'),
+    user: const User(
+      id: 'toomas',
+      name: 'Toomas Vahter',
+      image: 'https://avatars.githubusercontent.com/u/1469907',
+    ),
     token: _tokenForUser('toomas'),
   );
 
@@ -85,10 +106,19 @@ class UserCredentials {
 
   // Built-in list sorted by name
   static List<UserCredentials> get builtIn {
-    final users = [luke, martin, tommaso, thierry, marcelo, kanat, toomas];
-    return users.sorted(
-      (a, b) => a.user.name.toLowerCase().compareTo(b.user.name.toLowerCase()),
-    );
+    final users = [
+      sahil,
+      rene,
+      maciej,
+      martin,
+      tommaso,
+      thierry,
+      marcelo,
+      kanat,
+      toomas,
+    ];
+
+    return users;
   }
 
   // Helper method to get credentials by ID

--- a/sample_app/lib/screens/choose_user/choose_user_screen.dart
+++ b/sample_app/lib/screens/choose_user/choose_user_screen.dart
@@ -76,6 +76,7 @@ class UserSelectionList extends StatelessWidget {
         final credential = UserCredentials.builtIn[index];
 
         return ListTile(
+          key: Key(credential.user.id),
           onTap: () => onUserSelected?.call(credential),
           visualDensity: VisualDensity.compact,
           leading: UserAvatar.listTile(user: credential.user),


### PR DESCRIPTION
This commit updates the user data and API key used in the sample application.

Key changes:
- Replaced "luke_skywalker" user with new users: "sahil", "rene", and "maciej".
- Updated user details (name, image URL, and corresponding tokens) for existing users (martin, tommaso, thierry, marcelo, kanat, toomas) to reflect real Stream team members.
- Changed the production API key in `DemoAppConfig`.
- Removed manual sorting of the user list in `UserCredentials.builtIn` as the list is now provided in a pre-sorted order.
- Added a `Key` to the `ListTile` in `ChooseUserScreen` for better widget identification.