### PR TITLE
feat(samples): Show splash while authenticating

### DIFF
--- a/sample_app/lib/app/content/auth_controller.dart
+++ b/sample_app/lib/app/content/auth_controller.dart
@@ -23,6 +23,8 @@ class AuthController extends ValueNotifier<AuthState> {
   PushTokenManager? _pushTokenManager;
 
   Future<void> connect(UserCredentials credentials) async {
+    value = const Authenticating();
+
     final token = UserToken(credentials.token);
 
     final client = StreamFeedsClient(
@@ -82,4 +84,8 @@ final class Authenticated extends AuthState {
 
 final class Unauthenticated extends AuthState {
   const Unauthenticated();
+}
+
+final class Authenticating extends AuthState {
+  const Authenticating();
 }

--- a/sample_app/lib/navigation/app_router.dart
+++ b/sample_app/lib/navigation/app_router.dart
@@ -7,6 +7,7 @@ import 'package:stream_feeds/stream_feeds.dart';
 import '../screens/choose_user/choose_user_screen.dart';
 import '../screens/home/home_screen.dart';
 import '../screens/user_feed/user_feed_screen.dart';
+import '../widgets/app_splash.dart';
 import '../widgets/attachment_gallery/attachment_gallery.dart';
 import '../widgets/attachment_gallery/attachment_metadata.dart';
 import 'guards/auth_guard.dart';
@@ -43,6 +44,11 @@ class AppRouter extends RootStackRouter {
       AutoRoute(
         path: '/choose_user',
         page: ChooseUserRoute.page,
+        keepHistory: false,
+      ),
+      AutoRoute(
+        path: '/loading',
+        page: AppSplashRoute.page,
         keepHistory: false,
       ),
       AutoRoute(

--- a/sample_app/lib/navigation/app_router.gr.dart
+++ b/sample_app/lib/navigation/app_router.gr.dart
@@ -11,6 +11,22 @@
 part of 'app_router.dart';
 
 /// generated route for
+/// [AppSplash]
+class AppSplashRoute extends PageRouteInfo<void> {
+  const AppSplashRoute({List<PageRouteInfo>? children})
+      : super(AppSplashRoute.name, initialChildren: children);
+
+  static const String name = 'AppSplashRoute';
+
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      return const AppSplash();
+    },
+  );
+}
+
+/// generated route for
 /// [AttachmentGalleryPage]
 class AttachmentGalleryRoute extends PageRouteInfo<AttachmentGalleryRouteArgs> {
   AttachmentGalleryRoute({

--- a/sample_app/lib/navigation/guards/auth_guard.dart
+++ b/sample_app/lib/navigation/guards/auth_guard.dart
@@ -15,6 +15,12 @@ class AuthGuard extends AutoRouteGuard {
     final isAuthenticated = _authController.value is Authenticated;
     // If the user is authenticated, allow navigation to the requested route.
     if (isAuthenticated) return resolver.next();
+
+    // If the user is being authenticated, show the splash screen.
+    if (_authController.value is Authenticating) {
+      resolver.redirectUntil(const AppSplashRoute(), replace: true);
+    }
+
     // Otherwise, redirect to the Choose user page.
     resolver.redirectUntil(const ChooseUserRoute(), replace: true);
   }

--- a/sample_app/lib/widgets/app_splash.dart
+++ b/sample_app/lib/widgets/app_splash.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
@@ -7,6 +8,7 @@ import '../theme/theme.dart';
 ///
 /// Displays only the app logo in a clean, minimal style while the app initializes.
 /// Follows true minimalistic principles with perfect simplicity.
+@RoutePage(name: 'AppSplashRoute')
 class AppSplash extends StatelessWidget {
   const AppSplash({super.key});
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Currently when you load the app the 'choose user screen' is always shown, even though it forwards you very soon to the logged in screen. This PR replaces that with the splash screen if you start the app while already being logged in.

