### PR TITLE
feat(llc): relisten to websocket events after reconnect

### DIFF
--- a/packages/stream_feeds/CHANGELOG.md
+++ b/packages/stream_feeds/CHANGELOG.md
@@ -1,3 +1,6 @@
+## NEXT
+- Re-watch websocket events for feeds when the websocket reconnects.
+
 ## 0.2.0
 - [BREAKING] Update API client code, specifically the FeedOwnCapability enum.
 - Fix unknown enums for `List<FeedOwnCapability>` in `GetOrCreateFeedResponse` to be `FeedOwnCapability.unknown`.

--- a/packages/stream_feeds/lib/src/state/feed.dart
+++ b/packages/stream_feeds/lib/src/state/feed.dart
@@ -5,7 +5,6 @@ import 'package:rxdart/rxdart.dart';
 import 'package:state_notifier/state_notifier.dart';
 import 'package:stream_core/stream_core.dart';
 
-import '../../stream_feeds.dart';
 import '../generated/api/api.dart' as api;
 import '../models/activity_data.dart';
 import '../models/bookmark_data.dart';


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Closes FLU-252

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
This adds a reconnected stream which is observed by the feed, so when the websocket reconnects it gets the feed again so it's also observed again on the new websocket connection.