### PR TITLE
fix(repo): Update README to remove alpha note for Activity Feeds V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ This is the official Flutter SDK for StreamFeeds, a platform for building apps w
 
 For detailed examples and supported features, please check out our [docs](https://getstream.io/activity-feeds/docs/flutter/).
 
-Note: Activity Feeds V3 is in closed alpha — do not use it in production (just yet).
-
 ## What is Stream?
 
 Stream allows developers to rapidly deploy scalable feeds, chat messaging and video with an industry leading 99.999% uptime SLA guarantee.

--- a/packages/stream_feeds/README.md
+++ b/packages/stream_feeds/README.md
@@ -4,8 +4,6 @@ This is the official Flutter SDK for StreamFeeds, a platform for building apps w
 
 For detailed examples and supported features, please check out our [docs](https://getstream.io/activity-feeds/docs/flutter/).
 
-Note: Activity Feeds V3 is in closed alpha — do not use it in production (just yet).
-
 ## What is Stream?
 
 Stream allows developers to rapidly deploy scalable feeds, chat messaging and video with an industry leading 99.999% uptime SLA guarantee.


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Feeds V3 is not in alpha anymore for some time already, so this should be gone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed advisory notices from README documentation cautioning that Activity Feeds V3 is in closed alpha status and should not be used in production environments
  * Updated multiple repository README files to eliminate product status warnings and restrictions
  * Documentation now better reflects the current availability and full support status of Activity Feeds V3

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->