### PR TITLE
feat(llc): expose deleteNotificationActivity on delete methods

### DIFF
--- a/docs/code_snippets/05_06_notification_feeds.dart
+++ b/docs/code_snippets/05_06_notification_feeds.dart
@@ -71,3 +71,60 @@ Future<void> markNotificationsAsRead() async {
     ),
   );
 }
+
+/// New notification types: `mention` and `comment_mention`.
+///
+/// These are created by the backend automatically when a user is mentioned in
+/// an activity or a comment. They appear as notification activities alongside
+/// the standard types (follow, reaction, comment).
+Future<void> readMentionNotifications() async {
+  final notificationFeed = client.feed(group: 'notification', id: 'jane');
+  await notificationFeed.getOrCreate();
+
+  for (final group in notificationFeed.state.aggregatedActivities) {
+    for (final activity in group.activities) {
+      switch (activity.type) {
+        case 'mention':
+          print('${activity.user.name} mentioned you in an activity');
+        case 'comment_mention':
+          print('${activity.user.name} mentioned you in a comment');
+        default:
+          print('Notification type: ${activity.type}');
+      }
+    }
+  }
+}
+
+/// Delete a notification activity together with its source (activity, comment,
+/// or reaction) by passing `deleteNotificationActivity: true`.
+///
+/// This removes both the original item and the notification it created, which
+/// is useful when a user deletes content they no longer want to appear in
+/// others' notification feeds.
+Future<void> deleteWithNotification() async {
+  // Delete an activity and its notification
+  await feed.deleteActivity(
+    id: 'activity_123',
+    deleteNotificationActivity: true,
+  );
+
+  // Delete a comment and its notification
+  await feed.deleteComment(
+    commentId: 'comment_456',
+    deleteNotificationActivity: true,
+  );
+
+  // Delete a reaction and its notification
+  await feed.deleteActivityReaction(
+    activityId: 'activity_123',
+    type: 'like',
+    deleteNotificationActivity: true,
+  );
+
+  // Delete a comment reaction and its notification
+  await feed.deleteCommentReaction(
+    commentId: 'comment_456',
+    type: 'like',
+    deleteNotificationActivity: true,
+  );
+}

--- a/docs/code_snippets/05_06_notification_feeds.dart
+++ b/docs/code_snippets/05_06_notification_feeds.dart
@@ -85,9 +85,9 @@ Future<void> readMentionNotifications() async {
     for (final activity in group.activities) {
       switch (activity.type) {
         case 'mention':
-          print('${activity.user.name} mentioned you in an activity');
+          print('${activity.user.name ?? 'Someone'} mentioned you in an activity');
         case 'comment_mention':
-          print('${activity.user.name} mentioned you in a comment');
+          print('${activity.user.name ?? 'Someone'} mentioned you in a comment');
         default:
           print('Notification type: ${activity.type}');
       }

--- a/packages/stream_feeds/CHANGELOG.md
+++ b/packages/stream_feeds/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `bookmarkCount` and `editedAt` fields to `CommentData`.
 - Added `location` (`LocationCoordinate?`) field to `FeedData`.
 - Added `createNotificationActivity`, `skipPush`, and `enrichOwnFields` optional flags to `FeedAddActivityRequest`.
+- Added optional `deleteNotificationActivity` parameter to `Feed.deleteActivity`, `Feed.deleteComment`, `Feed.deleteActivityReaction`, `Feed.deleteCommentReaction`, `Activity.deleteComment`, and `Activity.deleteCommentReaction` — when `true`, the corresponding notification activity is also deleted.
 
 ### WebSocket events
 - `ActivityRestoredEvent` and `CommentRestoredEvent` are now handled: restored items are upserted back into feed/list state.

--- a/packages/stream_feeds/lib/src/repository/activities_repository.dart
+++ b/packages/stream_feeds/lib/src/repository/activities_repository.dart
@@ -54,10 +54,12 @@ class ActivitiesRepository {
   Future<Result<void>> deleteActivity(
     String activityId, {
     required bool hardDelete,
+    bool? deleteNotificationActivity,
   }) {
     return _api.deleteActivity(
       id: activityId,
       hardDelete: hardDelete,
+      deleteNotificationActivity: deleteNotificationActivity,
     );
   }
 
@@ -245,11 +247,13 @@ class ActivitiesRepository {
   /// was removed, and the `reaction` field contains the deleted [FeedsReactionData].
   Future<Result<({ActivityData activity, FeedsReactionData reaction})>> deleteActivityReaction(
     String activityId,
-    String type,
-  ) async {
+    String type, {
+    bool? deleteNotificationActivity,
+  }) async {
     final result = await _api.deleteActivityReaction(
       activityId: activityId,
       type: type,
+      deleteNotificationActivity: deleteNotificationActivity,
     );
 
     return result.map(

--- a/packages/stream_feeds/lib/src/repository/comments_repository.dart
+++ b/packages/stream_feeds/lib/src/repository/comments_repository.dart
@@ -135,10 +135,12 @@ class CommentsRepository {
   Future<Result<({ActivityData activity, CommentData comment})>> deleteComment(
     String commentId, {
     bool? hardDelete,
+    bool? deleteNotificationActivity,
   }) async {
     final result = await _api.deleteComment(
       id: commentId,
       hardDelete: hardDelete,
+      deleteNotificationActivity: deleteNotificationActivity,
     );
 
     return result.map(
@@ -208,9 +210,14 @@ class CommentsRepository {
   /// [FeedsReactionData] or an error.
   Future<Result<({CommentData comment, FeedsReactionData reaction})>> deleteCommentReaction(
     String commentId,
-    String type,
-  ) async {
-    final result = await _api.deleteCommentReaction(id: commentId, type: type);
+    String type, {
+    bool? deleteNotificationActivity,
+  }) async {
+    final result = await _api.deleteCommentReaction(
+      id: commentId,
+      type: type,
+      deleteNotificationActivity: deleteNotificationActivity,
+    );
 
     return result.map(
       (response) => (

--- a/packages/stream_feeds/lib/src/state/activity.dart
+++ b/packages/stream_feeds/lib/src/state/activity.dart
@@ -230,10 +230,12 @@ class Activity with Disposable {
   Future<Result<void>> deleteComment(
     String commentId, {
     bool? hardDelete,
+    bool? deleteNotificationActivity,
   }) async {
     final result = await commentsRepository.deleteComment(
       commentId,
       hardDelete: hardDelete,
+      deleteNotificationActivity: deleteNotificationActivity,
     );
 
     result.onSuccess(
@@ -303,11 +305,13 @@ class Activity with Disposable {
   /// Returns a [Result] containing the removed [FeedsReactionData] or an error.
   Future<Result<FeedsReactionData>> deleteCommentReaction(
     String commentId,
-    String type,
-  ) async {
+    String type, {
+    bool? deleteNotificationActivity,
+  }) async {
     final result = await commentsRepository.deleteCommentReaction(
       commentId,
       type,
+      deleteNotificationActivity: deleteNotificationActivity,
     );
 
     result.onSuccess(

--- a/packages/stream_feeds/lib/src/state/feed.dart
+++ b/packages/stream_feeds/lib/src/state/feed.dart
@@ -265,10 +265,12 @@ class Feed with Disposable {
   Future<Result<void>> deleteActivity({
     required String id,
     bool hardDelete = false,
+    bool? deleteNotificationActivity,
   }) async {
     final result = await activitiesRepository.deleteActivity(
       id,
       hardDelete: hardDelete,
+      deleteNotificationActivity: deleteNotificationActivity,
     );
 
     result.onSuccess(
@@ -469,8 +471,14 @@ class Feed with Disposable {
   ///
   /// The [commentId] is the unique identifier of the comment to remove.
   /// Returns a [Result] indicating success or failure of the deletion operation.
-  Future<Result<void>> deleteComment({required String commentId}) async {
-    final result = await commentsRepository.deleteComment(commentId);
+  Future<Result<void>> deleteComment({
+    required String commentId,
+    bool? deleteNotificationActivity,
+  }) async {
+    final result = await commentsRepository.deleteComment(
+      commentId,
+      deleteNotificationActivity: deleteNotificationActivity,
+    );
 
     result.onSuccess(
       (pair) {
@@ -791,10 +799,12 @@ class Feed with Disposable {
   Future<Result<FeedsReactionData>> deleteActivityReaction({
     required String activityId,
     required String type,
+    bool? deleteNotificationActivity,
   }) async {
     final result = await activitiesRepository.deleteActivityReaction(
       activityId,
       type,
+      deleteNotificationActivity: deleteNotificationActivity,
     );
 
     result.onSuccess(
@@ -848,10 +858,12 @@ class Feed with Disposable {
   Future<Result<FeedsReactionData>> deleteCommentReaction({
     required String commentId,
     required String type,
+    bool? deleteNotificationActivity,
   }) async {
     final result = await commentsRepository.deleteCommentReaction(
       commentId,
       type,
+      deleteNotificationActivity: deleteNotificationActivity,
     );
 
     result.onSuccess(

--- a/packages/stream_feeds/test/state/activity_test.dart
+++ b/packages/stream_feeds/test/state/activity_test.dart
@@ -657,6 +657,51 @@ void main() {
     );
 
     activityTest(
+      'deleteComment - should pass deleteNotificationActivity to API',
+      build: (client) => client.activity(activityId: activityId, fid: fid),
+      setUp: (tester) => tester.get(
+        modifyCommentsResponse: (response) => response.copyWith(
+          comments: [
+            createDefaultThreadedCommentResponse(
+              id: commentId,
+              objectId: activityId,
+              objectType: 'activity',
+              text: 'Test comment',
+              userId: userId,
+            ),
+          ],
+        ),
+      ),
+      body: (tester) async {
+        tester.mockApi(
+          (api) => api.deleteComment(
+            id: commentId,
+            deleteNotificationActivity: true,
+          ),
+          result: createDefaultDeleteCommentResponse(
+            commentId: commentId,
+            activityId: activityId,
+            objectId: activityId,
+            userId: userId,
+          ),
+        );
+
+        final result = await tester.activity.deleteComment(
+          commentId,
+          deleteNotificationActivity: true,
+        );
+
+        expect(result.isSuccess, isTrue);
+      },
+      verify: (tester) => tester.verifyApi(
+        (api) => api.deleteComment(
+          id: commentId,
+          deleteNotificationActivity: true,
+        ),
+      ),
+    );
+
+    activityTest(
       'updateComment - should update comment via API',
       build: (client) => client.activity(activityId: activityId, fid: fid),
       setUp: (tester) => tester.get(
@@ -1008,6 +1053,62 @@ void main() {
         (api) => api.deleteCommentReaction(
           id: commentId,
           type: reactionType,
+        ),
+      ),
+    );
+
+    activityTest(
+      'deleteCommentReaction - should pass deleteNotificationActivity to API',
+      build: (client) => client.activity(activityId: activityId, fid: fid),
+      setUp: (tester) => tester.get(
+        modifyCommentsResponse: (response) => response.copyWith(
+          comments: [
+            createDefaultThreadedCommentResponse(
+              id: commentId,
+              objectId: activityId,
+              objectType: 'activity',
+              text: 'Test comment',
+              userId: userId,
+              ownReactions: [
+                createDefaultReactionResponse(
+                  reactionType: reactionType,
+                  userId: userId,
+                  activityId: activityId,
+                  commentId: commentId,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+      body: (tester) async {
+        tester.mockApi(
+          (api) => api.deleteCommentReaction(
+            id: commentId,
+            type: reactionType,
+            deleteNotificationActivity: true,
+          ),
+          result: createDefaultDeleteCommentReactionResponse(
+            commentId: commentId,
+            objectId: activityId,
+            userId: userId,
+            reactionType: reactionType,
+          ),
+        );
+
+        final result = await tester.activity.deleteCommentReaction(
+          commentId,
+          reactionType,
+          deleteNotificationActivity: true,
+        );
+
+        expect(result.isSuccess, isTrue);
+      },
+      verify: (tester) => tester.verifyApi(
+        (api) => api.deleteCommentReaction(
+          id: commentId,
+          type: reactionType,
+          deleteNotificationActivity: true,
         ),
       ),
     );

--- a/packages/stream_feeds/test/state/feed_test.dart
+++ b/packages/stream_feeds/test/state/feed_test.dart
@@ -3134,6 +3134,57 @@ void main() {
     );
 
     feedTest(
+      'deleteActivityReaction() - should pass deleteNotificationActivity to API',
+      build: (client) => client.feedFromId(feedId),
+      setUp: (tester) => tester.getOrCreate(
+        modifyResponse: (it) => it.copyWith(
+          activities: [
+            createDefaultActivityResponse(
+              id: 'activity-1',
+              feeds: [feedId.rawValue],
+              ownReactions: [
+                createDefaultReactionResponse(
+                  reactionType: 'heart',
+                  userId: userId,
+                  activityId: 'activity-1',
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+      body: (tester) async {
+        tester.mockApi(
+          (api) => api.deleteActivityReaction(
+            activityId: 'activity-1',
+            type: 'heart',
+            deleteNotificationActivity: true,
+          ),
+          result: createDefaultDeleteReactionResponse(
+            activityId: 'activity-1',
+            userId: userId,
+            reactionType: 'heart',
+          ),
+        );
+
+        final result = await tester.feed.deleteActivityReaction(
+          activityId: 'activity-1',
+          type: 'heart',
+          deleteNotificationActivity: true,
+        );
+
+        expect(result.isSuccess, isTrue);
+      },
+      verify: (tester) => tester.verifyApi(
+        (api) => api.deleteActivityReaction(
+          activityId: 'activity-1',
+          type: 'heart',
+          deleteNotificationActivity: true,
+        ),
+      ),
+    );
+
+    feedTest(
       'ActivityReactionDeletedEvent - should handle event and update activity',
       build: (client) => client.feedFromId(feedId),
       setUp: (tester) => tester.getOrCreate(

--- a/packages/stream_feeds/test/state/feed_test.dart
+++ b/packages/stream_feeds/test/state/feed_test.dart
@@ -373,6 +373,45 @@ void main() {
     );
 
     feedTest(
+      'deleteActivity() - should pass deleteNotificationActivity to API',
+      build: (client) => client.feedFromId(feedId),
+      setUp: (tester) => tester.getOrCreate(
+        modifyResponse: (it) => it.copyWith(
+          activities: [
+            createDefaultActivityResponse(
+              id: 'activity-1',
+              feeds: [feedId.rawValue],
+            ),
+          ],
+        ),
+      ),
+      body: (tester) async {
+        tester.mockApi(
+          (api) => api.deleteActivity(
+            id: 'activity-1',
+            hardDelete: false,
+            deleteNotificationActivity: true,
+          ),
+          result: const DeleteActivityResponse(duration: '0ms'),
+        );
+
+        final result = await tester.feed.deleteActivity(
+          id: 'activity-1',
+          deleteNotificationActivity: true,
+        );
+
+        expect(result.isSuccess, isTrue);
+      },
+      verify: (tester) => tester.verifyApi(
+        (api) => api.deleteActivity(
+          id: 'activity-1',
+          hardDelete: false,
+          deleteNotificationActivity: true,
+        ),
+      ),
+    );
+
+    feedTest(
       'activityFeedback() - should submit feedback via API',
       build: (client) => client.feedFromId(feedId),
       setUp: (tester) => tester.getOrCreate(),
@@ -1567,6 +1606,53 @@ void main() {
     );
 
     feedTest(
+      'deleteComment() - should pass deleteNotificationActivity to API',
+      user: currentUser,
+      build: (client) => client.feedFromId(feedId),
+      setUp: (tester) => tester.getOrCreate(
+        modifyResponse: (it) => it.copyWith(
+          activities: [
+            createDefaultActivityResponse(
+              id: 'activity-1',
+              feeds: [feedId.rawValue],
+            ),
+          ],
+        ),
+      ),
+      body: (tester) async {
+        tester.mockApi(
+          (api) => api.deleteComment(
+            id: commentId,
+            hardDelete: null,
+            deleteNotificationActivity: true,
+          ),
+          result: DeleteCommentResponse(
+            activity: createDefaultActivityResponse(id: 'activity-1'),
+            comment: createDefaultCommentResponse(
+              id: commentId,
+              objectId: 'activity-1',
+            ),
+            duration: '0ms',
+          ),
+        );
+
+        final result = await tester.feed.deleteComment(
+          commentId: commentId,
+          deleteNotificationActivity: true,
+        );
+
+        expect(result.isSuccess, isTrue);
+      },
+      verify: (tester) => tester.verifyApi(
+        (api) => api.deleteComment(
+          id: commentId,
+          hardDelete: null,
+          deleteNotificationActivity: true,
+        ),
+      ),
+    );
+
+    feedTest(
       'addCommentReaction() - should add reaction to comment',
       user: currentUser,
       build: (client) => client.feedFromId(feedId),
@@ -1665,6 +1751,52 @@ void main() {
       },
       verify: (tester) => tester.verifyApi(
         (api) => api.deleteCommentReaction(id: commentId, type: 'like'),
+      ),
+    );
+
+    feedTest(
+      'deleteCommentReaction() - should pass deleteNotificationActivity to API',
+      user: currentUser,
+      build: (client) => client.feedFromId(feedId),
+      setUp: (tester) => tester.getOrCreate(
+        modifyResponse: (it) => it.copyWith(
+          activities: [
+            createDefaultActivityResponse(
+              id: 'activity-1',
+              feeds: [feedId.rawValue],
+            ),
+          ],
+        ),
+      ),
+      body: (tester) async {
+        tester.mockApi(
+          (api) => api.deleteCommentReaction(
+            id: commentId,
+            type: 'like',
+            deleteNotificationActivity: true,
+          ),
+          result: createDefaultDeleteCommentReactionResponse(
+            commentId: commentId,
+            objectId: 'activity-1',
+            userId: currentUser.id,
+            reactionType: 'like',
+          ),
+        );
+
+        final result = await tester.feed.deleteCommentReaction(
+          commentId: commentId,
+          type: 'like',
+          deleteNotificationActivity: true,
+        );
+
+        expect(result.isSuccess, isTrue);
+      },
+      verify: (tester) => tester.verifyApi(
+        (api) => api.deleteCommentReaction(
+          id: commentId,
+          type: 'like',
+          deleteNotificationActivity: true,
+        ),
       ),
     );
 


### PR DESCRIPTION
## Summary
- Added optional `deleteNotificationActivity: bool?` to `Feed.deleteActivity`, `Feed.deleteComment`, `Feed.deleteActivityReaction`, `Feed.deleteCommentReaction`, `Activity.deleteComment`, and `Activity.deleteCommentReaction`
- Plumbed through the repository layer to the generated API `delete_notification_activity` query param (already present from codegen #106)
- New notification types `mention` and `comment_mention` require no SDK changes — they are standard activity types handled generically; the snippet documents how to read them

## Relevance check
The `delete_notification_activity` query param was already in the generated `DefaultApi` (PR #106) but was not exposed on any public SDK method. New notification types (`mention`, `comment_mention`) only need docs — they appear as activity types in aggregated notification activities with no special handling needed.

## Test plan
- [ ] `melos run analyze` — no issues
- [ ] `flutter test` in `packages/stream_feeds` — all 392 tests pass
- [ ] Docs snippet in `docs/code_snippets/05_06_notification_feeds.dart` (new functions) compiles cleanly

Closes FLU-372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to remove related notifications when deleting activities, comments, or reactions.
  * Expanded examples to show how to read mention notifications and delete content while also clearing associated notifications.

* **Bug Fixes**
  * Improved consistency so deletion actions can now clean up the linked notification entry at the same time.

* **Chores**
  * Updated the changelog and added test coverage for the new deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->