### PR TITLE
feat(llc): implement real guest token flow via createGuest

### DIFF
--- a/docs/code_snippets/02_02_authentication.dart
+++ b/docs/code_snippets/02_02_authentication.dart
@@ -1,0 +1,58 @@
+import 'package:stream_feeds/stream_feeds.dart';
+
+Future<void> regularUserLogin() async {
+  // Regular user: provide a JWT token (from your server).
+  final client = StreamFeedsClient(
+    apiKey: '<your_api_key>',
+    user: const User(id: 'alice'),
+    tokenProvider: TokenProvider.static(UserToken('<your_jwt_token>')),
+  );
+  await client.connect();
+}
+
+Future<void> dynamicTokenProvider() async {
+  // Dynamic token provider: fetches a new token from your server
+  // when the current one expires.
+  final client = StreamFeedsClient(
+    apiKey: '<your_api_key>',
+    user: const User(id: 'alice'),
+    tokenProvider: TokenProvider.dynamic((userId) async {
+      // Fetch a fresh JWT for `userId` from your backend.
+      final token = await fetchTokenFromYourServer(userId);
+      return UserToken(token);
+    }),
+  );
+  await client.connect();
+}
+
+// Placeholder for your server token fetch
+Future<String> fetchTokenFromYourServer(String userId) async => '<jwt>';
+
+Future<void> guestUserLogin() async {
+  // Guest user: the SDK automatically calls POST /api/v2/guest to obtain
+  // a temporary JWT — no tokenProvider is needed.
+  // Guest users have full read/write access and a real WebSocket connection,
+  // but their session is temporary and not tied to a persistent account.
+  final client = StreamFeedsClient(
+    apiKey: '<your_api_key>',
+    user: User.guest('guest-${DateTime.now().millisecondsSinceEpoch}'),
+  );
+  await client.connect(); // Guest JWT is fetched automatically on connect.
+
+  final feed = client.feed(group: 'user', id: client.user.id);
+  await feed.getOrCreate();
+}
+
+Future<void> anonymousUserLogin() async {
+  // Anonymous user: read-only access with no JWT or WebSocket connection.
+  // Use this for public feeds that don't require authentication.
+  // Note: calling connect() throws for anonymous users.
+  final client = StreamFeedsClient(
+    apiKey: '<your_api_key>',
+    user: const User.anonymous(),
+  );
+
+  // Read public feed data without connecting.
+  final feed = client.feed(group: 'user', id: 'alice');
+  await feed.getOrCreate();
+}

--- a/melos.yaml
+++ b/melos.yaml
@@ -48,7 +48,10 @@ command:
       state_notifier: ^1.0.0
       stream_feeds: ^0.5.1
       stream_core: 
-        path: /Users/renefloor/Documents/github/stream-core-flutter/packages/stream_core
+        git:
+          url: https://github.com/GetStream/stream-core-flutter.git
+          ref: 718e2730d2380db9a61575e006fe1a89dc3e5e2a
+          path: packages/stream_core
       video_player: ^2.10.0
       uuid: ^4.5.1
       web_socket_channel: ^3.0.0

--- a/melos.yaml
+++ b/melos.yaml
@@ -47,7 +47,8 @@ command:
       shared_preferences: ^2.5.3
       state_notifier: ^1.0.0
       stream_feeds: ^0.5.1
-      stream_core: ^0.4.0
+      stream_core: 
+        path: /Users/renefloor/Documents/github/stream-core-flutter/packages/stream_core
       video_player: ^2.10.0
       uuid: ^4.5.1
       web_socket_channel: ^3.0.0

--- a/packages/stream_feeds/CHANGELOG.md
+++ b/packages/stream_feeds/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Upcoming
 
+### Improvements
+- Guest users (`User.guest(id)`) now obtain a real JWT by calling `POST /api/v2/guest` during `connect()`, giving them a full authenticated session with WebSocket support. Previously guest users fell back to the anonymous token which prevented WS connectivity.
+
 ### New fields
 - Added `isRead` and `isSeen` fields to `ActivityData` and `AggregatedActivityData` for notification-feed read/seen state.
 - Added `friendReactionCount` and `friendReactions` fields to `ActivityData` to expose reactions from friends.

--- a/packages/stream_feeds/CHANGELOG.md
+++ b/packages/stream_feeds/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Upcoming
 
 ### Improvements
-- Guest users (`User.guest(id)`) now obtain a real JWT by calling `POST /api/v2/guest` during `connect()`, giving them a full authenticated session with WebSocket support. Previously guest users fell back to the anonymous token which prevented WS connectivity.
+- Guest users (`User.guest(id)`) now obtain a real JWT by calling `POST /api/v2/guest` during `connect()`, giving them a full authenticated session with WebSocket support. Previously guest users fell back to the anonymous token which prevented WS connectivity. If the backend assigns a different id to the guest user, `client.user` is updated to match it.
 
 ### New fields
 - Added `isRead` and `isSeen` fields to `ActivityData` and `AggregatedActivityData` for notification-feed read/seen state.

--- a/packages/stream_feeds/lib/src/client/feeds_client_impl.dart
+++ b/packages/stream_feeds/lib/src/client/feeds_client_impl.dart
@@ -84,9 +84,41 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
       (UserType.regular, null) => throw ArgumentError(
         'TokenProvider must be provided for regular users.',
       ),
-      (UserType.anonymous || UserType.guest, _) => TokenProvider.static(
+      (UserType.anonymous, _) => TokenProvider.static(
         UserToken.anonymous(userId: user.id),
       ),
+      (UserType.guest, _) => TokenProvider.dynamic((_) async {
+        // Create a minimal unauthenticated HTTP client for the guest endpoint.
+        // This client only carries the API key header — no auth token needed.
+        final guestHttpClient =
+            StreamCoreHttpClient(
+              options: BaseOptions(
+                baseUrl: endpointConfig.baseFeedsUrl,
+                connectTimeout: const Duration(seconds: 6),
+                receiveTimeout: const Duration(seconds: 6),
+              ),
+            ).apply(
+              (client) => client.interceptors.addAll([
+                ApiKeyInterceptor(apiKey),
+                HeadersInterceptor(_systemEnvironmentManager),
+                const ApiErrorInterceptor(),
+              ]),
+            );
+
+        final guestApi = api.DefaultApi(guestHttpClient);
+        final result = await guestApi.createGuest(
+          createGuestRequest: api.CreateGuestRequest(
+            user: api.UserRequest(
+              id: user.id,
+              name: user.originalName,
+              image: user.image,
+              custom: user.custom.isEmpty ? null : user.custom,
+            ),
+          ),
+        );
+
+        return result.map((r) => UserToken(r.accessToken)).getOrThrow();
+      }),
     };
 
     _tokenManager = TokenManager(

--- a/packages/stream_feeds/lib/src/client/feeds_client_impl.dart
+++ b/packages/stream_feeds/lib/src/client/feeds_client_impl.dart
@@ -61,10 +61,17 @@ import '../state/query/polls_query.dart';
 import '../ws/feeds_ws_event.dart';
 import 'endpoint_config.dart';
 
+// Shared REST client options for both the main and guest-token HTTP clients.
+BaseOptions _restApiOptions(EndpointConfig endpointConfig) => BaseOptions(
+  baseUrl: endpointConfig.baseFeedsUrl,
+  connectTimeout: const Duration(seconds: 6),
+  receiveTimeout: const Duration(seconds: 6),
+);
+
 class StreamFeedsClientImpl implements StreamFeedsClient {
   StreamFeedsClientImpl({
     required this.apiKey,
-    required this.user,
+    required User user,
     this.config = const FeedsConfig(),
     TokenProvider? tokenProvider,
     RetryStrategy? retryStrategy,
@@ -74,7 +81,7 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
     WebSocketProvider? wsProvider,
     api.DefaultApi? feedsRestApi,
     api.DefaultApi? guestRestApi,
-  }) {
+  }) : _user = user {
     // TODO: Make this configurable
     const endpointConfig = EndpointConfig.production;
 
@@ -88,40 +95,20 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
       (UserType.anonymous, _) => TokenProvider.static(
         UserToken.anonymous(userId: user.id),
       ),
-      (UserType.guest, _) => TokenProvider.dynamic((_) async {
-        // Create a minimal unauthenticated HTTP client for the guest endpoint.
-        // This client only carries the API key header — no auth token needed.
-        final guestHttpClient =
-            StreamCoreHttpClient(
-              options: BaseOptions(
-                baseUrl: endpointConfig.baseFeedsUrl,
-                connectTimeout: const Duration(seconds: 6),
-                receiveTimeout: const Duration(seconds: 6),
-              ),
-            ).apply(
-              (client) => client.interceptors.addAll([
-                ApiKeyInterceptor(apiKey),
-                HeadersInterceptor(_systemEnvironmentManager),
-                const ApiErrorInterceptor(),
-              ]),
-            );
-
-        final guestApi = guestRestApi ?? api.DefaultApi(guestHttpClient);
-        final result = await guestApi.createGuest(
-          createGuestRequest: api.CreateGuestRequest(
-            user: api.UserRequest(
-              id: user.id,
-              name: user.originalName,
-              image: user.image,
-              custom: user.custom.isEmpty ? null : user.custom,
-            ),
-          ),
-        );
-
-        return result.map((r) => UserToken(r.accessToken)).getOrThrow();
-      }),
+      (UserType.guest, _) => _guestTokenProvider(
+        user: user,
+        apiKey: apiKey,
+        endpointConfig: endpointConfig,
+        guestRestApi: guestRestApi,
+      ),
     };
 
+    // Note: `_tokenManager.userId` stays fixed to the originally-requested
+    // id for the lifetime of this client, even though a guest user's
+    // `_user.id` may later be reassigned by the server (see
+    // `_guestTokenProvider`). REST calls stay consistent regardless, since
+    // `AuthInterceptor` derives the `user_id` query parameter from the
+    // resolved token itself rather than from `_tokenManager.userId`.
     _tokenManager = TokenManager(
       userId: user.id,
       tokenProvider: userTokenProvider,
@@ -168,11 +155,7 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
 
     final httpClient =
         StreamCoreHttpClient(
-          options: BaseOptions(
-            baseUrl: endpointConfig.baseFeedsUrl,
-            connectTimeout: const Duration(seconds: 6),
-            receiveTimeout: const Duration(seconds: 6),
-          ),
+          options: _restApiOptions(endpointConfig),
         ).apply(
           (client) => client.interceptors.addAll([
             ApiKeyInterceptor(apiKey),
@@ -217,8 +200,12 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
 
   final String apiKey;
 
+  // The current user identity. Mutable because a guest user's id/profile may
+  // be reassigned by the server once the guest token exchange completes; see
+  // [_guestTokenProvider].
   @override
-  final User user;
+  User get user => _user;
+  User _user;
 
   final FeedsConfig config;
 
@@ -259,21 +246,88 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
   @override
   late final ModerationClient moderation;
 
+  /// Builds the [TokenProvider] used to obtain a guest JWT.
+  ///
+  /// Guest users have no pre-issued token, so one is minted lazily via
+  /// `POST /api/v2/guest`, called through a dedicated, unauthenticated HTTP
+  /// client (built once and reused across token refreshes). The backend may
+  /// return a different id than the one requested, to avoid colliding with
+  /// an existing user, so [_user] is updated to the server's response to
+  /// keep the WS handshake and any `client.user` reads in sync with the
+  /// identity the token actually authenticates as.
+  TokenProvider _guestTokenProvider({
+    required User user,
+    required String apiKey,
+    required EndpointConfig endpointConfig,
+    api.DefaultApi? guestRestApi,
+  }) {
+    var guestApi = guestRestApi;
+
+    return TokenProvider.dynamic((_) async {
+      final guestApiClient = guestApi ??= api.DefaultApi(
+        StreamCoreHttpClient(options: _restApiOptions(endpointConfig)).apply(
+          (client) => client.interceptors.addAll([
+            ApiKeyInterceptor(apiKey),
+            HeadersInterceptor(_systemEnvironmentManager),
+            const ApiErrorInterceptor(),
+          ]),
+        ),
+      );
+
+      final result = await guestApiClient.createGuest(
+        createGuestRequest: api.CreateGuestRequest(
+          user: api.UserRequest(
+            id: user.id,
+            name: user.originalName,
+            image: user.image,
+            custom: user.custom.isEmpty ? null : user.custom,
+          ),
+        ),
+      );
+      final response = result.getOrThrow();
+
+      _user = User(
+        id: response.user.id,
+        name: response.user.name,
+        image: response.user.image,
+        role: response.user.role,
+        type: UserType.guest,
+        custom: response.user.custom,
+      );
+
+      return UserToken(response.accessToken);
+    });
+  }
+
   Future<void> _authenticateUser() async {
-    final userToken = await _tokenManager.getToken();
+    try {
+      final userToken = await _tokenManager.getToken();
 
-    final connectUserRequest = WsAuthMessageRequest(
-      products: const ['feeds'],
-      token: userToken.rawValue,
-      userDetails: ConnectUserDetailsRequest(
-        id: user.id,
-        name: user.originalName,
-        image: user.image,
-        custom: user.custom,
-      ),
-    );
+      final connectUserRequest = WsAuthMessageRequest(
+        products: const ['feeds'],
+        token: userToken.rawValue,
+        userDetails: ConnectUserDetailsRequest(
+          id: user.id,
+          name: user.originalName,
+          image: user.image,
+          custom: user.custom,
+        ),
+      );
 
-    _ws.send(connectUserRequest);
+      _ws.send(connectUserRequest);
+    } catch (error) {
+      // Without this, a token-loading failure (e.g. the guest exchange
+      // failing) would leave the connection stuck in `Authenticating`
+      // forever, since nothing else observes this callback's Future and
+      // `connect()` only resolves on a `Connected`/`Disconnected` state.
+      //
+      // The default `userInitiated` source (rather than `serverInitiated`) is
+      // used deliberately: this is a client-side failure to obtain a token
+      // at all, not a retryable server condition, and `serverInitiated` is
+      // eligible for automatic reconnection, which would otherwise retry
+      // the failing token load indefinitely.
+      await _ws.disconnect();
+    }
   }
 
   @override

--- a/packages/stream_feeds/lib/src/client/feeds_client_impl.dart
+++ b/packages/stream_feeds/lib/src/client/feeds_client_impl.dart
@@ -73,6 +73,7 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
     List<AutomaticReconnectionPolicy>? reconnectionPolicies,
     WebSocketProvider? wsProvider,
     api.DefaultApi? feedsRestApi,
+    api.DefaultApi? guestRestApi,
   }) {
     // TODO: Make this configurable
     const endpointConfig = EndpointConfig.production;
@@ -105,7 +106,7 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
               ]),
             );
 
-        final guestApi = api.DefaultApi(guestHttpClient);
+        final guestApi = guestRestApi ?? api.DefaultApi(guestHttpClient);
         final result = await guestApi.createGuest(
           createGuestRequest: api.CreateGuestRequest(
             user: api.UserRequest(

--- a/packages/stream_feeds/lib/src/client/feeds_client_impl.dart
+++ b/packages/stream_feeds/lib/src/client/feeds_client_impl.dart
@@ -103,12 +103,10 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
       ),
     };
 
-    // Note: `_tokenManager.userId` stays fixed to the originally-requested
-    // id for the lifetime of this client, even though a guest user's
-    // `_user.id` may later be reassigned by the server (see
-    // `_guestTokenProvider`). REST calls stay consistent regardless, since
-    // `AuthInterceptor` derives the `user_id` query parameter from the
-    // resolved token itself rather than from `_tokenManager.userId`.
+    // For guest users this starts with the originally-requested id and is
+    // swapped for a manager carrying the server-resolved id once the token
+    // exchange completes (see `_guestTokenProvider`). `AuthInterceptor` reads
+    // the manager through a getter, so it always sees the current instance.
     _tokenManager = TokenManager(
       userId: user.id,
       tokenProvider: userTokenProvider,
@@ -161,7 +159,7 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
             ApiKeyInterceptor(apiKey),
             HeadersInterceptor(_systemEnvironmentManager),
             if (user.type != UserType.anonymous) connectionIdInterceptor,
-            AuthInterceptor(client, _tokenManager),
+            AuthInterceptor(client, () => _tokenManager),
             const ApiErrorInterceptor(),
             LoggingInterceptor(requestHeader: true),
           ]),
@@ -209,7 +207,10 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
 
   final FeedsConfig config;
 
-  late final TokenManager _tokenManager;
+  // Not `final`: for guest users this is swapped for a manager carrying the
+  // server-resolved user id once the token exchange completes (see
+  // `_guestTokenProvider`).
+  late TokenManager _tokenManager;
   late final StreamWebSocketClient _ws;
   late final ConnectionRecoveryHandler _connectionRecoveryHandler;
 
@@ -250,11 +251,16 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
   ///
   /// Guest users have no pre-issued token, so one is minted lazily via
   /// `POST /api/v2/guest`, called through a dedicated, unauthenticated HTTP
-  /// client (built once and reused across token refreshes). The backend may
-  /// return a different id than the one requested, to avoid colliding with
-  /// an existing user, so [_user] is updated to the server's response to
-  /// keep the WS handshake and any `client.user` reads in sync with the
-  /// identity the token actually authenticates as.
+  /// client. The backend may return a different id than the one requested, to
+  /// avoid colliding with an existing user, so [_user] is updated to the
+  /// server's response to keep the WS handshake and any `client.user` reads in
+  /// sync with the identity the token actually authenticates as.
+  ///
+  /// Once the id is known, [_tokenManager] is swapped for one pinned to that id
+  /// with a static provider: the guest identity is established once (like an
+  /// anonymous user) rather than re-minted on every token load, and
+  /// `AuthInterceptor` — which reads the manager through a getter — picks up
+  /// the resolved id for the `user_id` query parameter.
   TokenProvider _guestTokenProvider({
     required User user,
     required String apiKey,
@@ -295,7 +301,16 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
         custom: response.user.custom,
       );
 
-      return UserToken(response.accessToken);
+      final token = UserToken(response.accessToken);
+
+      // Pin the manager to the resolved id so subsequent REST/WS calls use it
+      // without re-running the guest exchange.
+      _tokenManager = TokenManager(
+        userId: response.user.id,
+        tokenProvider: TokenProvider.static(token),
+      );
+
+      return token;
     });
   }
 

--- a/packages/stream_feeds/lib/src/client/feeds_client_impl.dart
+++ b/packages/stream_feeds/lib/src/client/feeds_client_impl.dart
@@ -250,20 +250,20 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
   @override
   late final ModerationClient moderation;
 
-  /// Builds the [TokenProvider] used to obtain a guest JWT.
-  ///
-  /// Guest users have no pre-issued token, so one is minted lazily via
-  /// `POST /api/v2/guest`, called through a dedicated, unauthenticated HTTP
-  /// client. The backend may return a different id than the one requested, to
-  /// avoid colliding with an existing user, so [_user] is updated to the
-  /// server's response to keep the WS handshake and any `client.user` reads in
-  /// sync with the identity the token actually authenticates as.
-  ///
-  /// Once the id is known, [_tokenManager] is swapped for one pinned to that id
-  /// with a static provider: the guest identity is established once (like an
-  /// anonymous user) rather than re-minted on every token load, and
-  /// `AuthInterceptor` — which reads the manager through a getter — picks up
-  /// the resolved id for the `user_id` query parameter.
+  // Builds the [TokenProvider] used to obtain a guest JWT.
+  //
+  // Guest users have no pre-issued token, so one is minted lazily via
+  // `POST /api/v2/guest`, called through a dedicated, unauthenticated HTTP
+  // client. The backend may return a different id than the one requested, to
+  // avoid colliding with an existing user, so [_user] is updated to the
+  // server's response to keep the WS handshake and any `client.user` reads in
+  // sync with the identity the token actually authenticates as.
+  //
+  // Once the id is known, [_tokenManager] is swapped for one pinned to that id
+  // with a static provider: the guest identity is established once (like an
+  // anonymous user) rather than re-minted on every token load, and
+  // `AuthInterceptor` — which reads the manager through a getter — picks up
+  // the resolved id for the `user_id` query parameter.
   TokenProvider _guestTokenProvider({
     required User user,
     required String apiKey,

--- a/packages/stream_feeds/lib/src/client/feeds_client_impl.dart
+++ b/packages/stream_feeds/lib/src/client/feeds_client_impl.dart
@@ -159,7 +159,10 @@ class StreamFeedsClientImpl implements StreamFeedsClient {
             ApiKeyInterceptor(apiKey),
             HeadersInterceptor(_systemEnvironmentManager),
             if (user.type != UserType.anonymous) connectionIdInterceptor,
-            AuthInterceptor(client, () => _tokenManager),
+            AuthInterceptor.withProvider(
+              client,
+              tokenManagerProvider: () => _tokenManager,
+            ),
             const ApiErrorInterceptor(),
             LoggingInterceptor(requestHeader: true),
           ]),

--- a/packages/stream_feeds/lib/src/feeds_client.dart
+++ b/packages/stream_feeds/lib/src/feeds_client.dart
@@ -169,6 +169,7 @@ abstract interface class StreamFeedsClient {
     List<AutomaticReconnectionPolicy>? reconnectionPolicies,
     @visibleForTesting WebSocketProvider? wsProvider,
     @visibleForTesting api.DefaultApi? feedsRestApi,
+    @visibleForTesting api.DefaultApi? guestRestApi,
   }) = StreamFeedsClientImpl;
 
   User get user;

--- a/packages/stream_feeds/pubspec.yaml
+++ b/packages/stream_feeds/pubspec.yaml
@@ -30,7 +30,8 @@ dependencies:
   retrofit: ^4.9.2
   rxdart: ^0.28.0
   state_notifier: ^1.0.0
-  stream_core: ^0.4.0
+  stream_core:
+    path: /Users/renefloor/Documents/github/stream-core-flutter/packages/stream_core
   uuid: ^4.5.1
 
 dev_dependencies:

--- a/packages/stream_feeds/pubspec.yaml
+++ b/packages/stream_feeds/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
     # pin stream_core_flutter to a git ref to iterate on it alongside this
     # SDK between its releases.
     #
-    # **Note:** Before publishing stream_chat_flutter, this MUST be swapped
+    # **Note:** Before publishing stream_feeds, this MUST be swapped
     # back to a pub version constraint — git deps are not allowed on pub.dev
     # and will block the release.
     # ignore: invalid_dependency

--- a/packages/stream_feeds/pubspec.yaml
+++ b/packages/stream_feeds/pubspec.yaml
@@ -31,6 +31,14 @@ dependencies:
   rxdart: ^0.28.0
   state_notifier: ^1.0.0
   stream_core:
+    # The ignore below silences `invalid_dependency` because we occasionally
+    # pin stream_core_flutter to a git ref to iterate on it alongside this
+    # SDK between its releases.
+    #
+    # **Note:** Before publishing stream_chat_flutter, this MUST be swapped
+    # back to a pub version constraint — git deps are not allowed on pub.dev
+    # and will block the release.
+    # ignore: invalid_dependency
     git:
       url: https://github.com/GetStream/stream-core-flutter.git
       ref: 718e2730d2380db9a61575e006fe1a89dc3e5e2a

--- a/packages/stream_feeds/pubspec.yaml
+++ b/packages/stream_feeds/pubspec.yaml
@@ -31,7 +31,10 @@ dependencies:
   rxdart: ^0.28.0
   state_notifier: ^1.0.0
   stream_core:
-    path: /Users/renefloor/Documents/github/stream-core-flutter/packages/stream_core
+    git:
+      url: https://github.com/GetStream/stream-core-flutter.git
+      ref: 718e2730d2380db9a61575e006fe1a89dc3e5e2a
+      path: packages/stream_core
   uuid: ^4.5.1
 
 dev_dependencies:

--- a/packages/stream_feeds/test/client/feeds_client_test.dart
+++ b/packages/stream_feeds/test/client/feeds_client_test.dart
@@ -943,11 +943,11 @@ void main() {
   group('connect as guest user', () {
     feedsClientTest(
       'should connect a guest user using the createGuest token flow',
-      user: User.guest('guest-123'),
+      user: const User.guest('guest-123'),
       connect: (tester) async {
         tester.mockApi(
           (api) => api.createGuest(
-            createGuestRequest: CreateGuestRequest(
+            createGuestRequest: const CreateGuestRequest(
               user: UserRequest(
                 id: 'guest-123',
                 name: 'guest-123',
@@ -964,7 +964,7 @@ void main() {
         await tester.client.connect();
         addTearDown(tester.client.disconnect);
       },
-      body: (tester) async {
+      body: (tester) {
         expect(
           tester.client.connectionState.value,
           isA<Connected>(),

--- a/packages/stream_feeds/test/client/feeds_client_test.dart
+++ b/packages/stream_feeds/test/client/feeds_client_test.dart
@@ -935,4 +935,41 @@ void main() {
       },
     );
   });
+
+  // ============================================================
+  // FEATURE: Guest User Authentication
+  // ============================================================
+
+  group('connect as guest user', () {
+    feedsClientTest(
+      'should connect a guest user using the createGuest token flow',
+      user: User.guest('guest-123'),
+      connect: (tester) async {
+        tester.mockApi(
+          (api) => api.createGuest(
+            createGuestRequest: CreateGuestRequest(
+              user: UserRequest(
+                id: 'guest-123',
+                name: 'guest-123',
+              ),
+            ),
+          ),
+          result: CreateGuestResponse(
+            accessToken: generateTestUserToken('guest-123').rawValue,
+            duration: '10ms',
+            user: createDefaultUserResponse(id: 'guest-123'),
+          ),
+        );
+        tester.mockSuccessfulAuth('guest-123');
+        await tester.client.connect();
+        addTearDown(tester.client.disconnect);
+      },
+      body: (tester) async {
+        expect(
+          tester.client.connectionState.value,
+          isA<Connected>(),
+        );
+      },
+    );
+  });
 }

--- a/packages/stream_feeds/test/client/feeds_client_test.dart
+++ b/packages/stream_feeds/test/client/feeds_client_test.dart
@@ -948,19 +948,22 @@ void main() {
         tester.mockApi(
           (api) => api.createGuest(
             createGuestRequest: const CreateGuestRequest(
-              user: UserRequest(
-                id: 'guest-123',
-                name: 'guest-123',
-              ),
+              user: UserRequest(id: 'guest-123'),
             ),
           ),
+          // The backend may reassign the id to avoid colliding with an
+          // existing user, so the mocked response intentionally differs
+          // from the requested id.
           result: CreateGuestResponse(
-            accessToken: generateTestUserToken('guest-123').rawValue,
+            accessToken: generateTestUserToken('guest-123-xyz').rawValue,
             duration: '10ms',
-            user: createDefaultUserResponse(id: 'guest-123'),
+            user: createDefaultUserResponse(
+              id: 'guest-123-xyz',
+              role: 'guest',
+            ),
           ),
         );
-        tester.mockSuccessfulAuth('guest-123');
+        tester.mockSuccessfulAuth('guest-123-xyz');
         await tester.client.connect();
         addTearDown(tester.client.disconnect);
       },
@@ -969,6 +972,49 @@ void main() {
           tester.client.connectionState.value,
           isA<Connected>(),
         );
+
+        // The client's exposed identity should be reconciled with the
+        // server-assigned guest user, not the originally-requested id.
+        expect(tester.client.user.id, 'guest-123-xyz');
+        expect(tester.client.user.type, UserType.guest);
+      },
+    );
+
+    feedsClientTest(
+      'should fail to connect a guest user when the createGuest call fails',
+      user: const User.guest('guest-123'),
+      connect: (tester) {
+        // Wires up the WebSocket mock so the connection can open; the auth
+        // handshake it configures is never reached since createGuest fails
+        // before a WsAuthMessageRequest is ever sent.
+        tester.mockSuccessfulAuth('guest-123');
+        tester.mockApiFailure(
+          (api) => api.createGuest(
+            createGuestRequest: const CreateGuestRequest(
+              user: UserRequest(id: 'guest-123'),
+            ),
+          ),
+          error: Exception('Failed to create guest'),
+        );
+      },
+      body: (tester) async {
+        final connectionStateExpectation = expectLater(
+          tester.client.connectionState,
+          emitsInOrder([
+            isA<Initialized>(),
+            isA<Connecting>(),
+            isA<Authenticating>(),
+            isA<Disconnecting>(),
+            isA<Disconnected>(),
+          ]),
+        );
+
+        await expectLater(
+          tester.client.connect(),
+          throwsA(isA<ClientException>()),
+        );
+
+        await connectionStateExpectation;
       },
     );
   });

--- a/packages/stream_feeds_test/lib/src/testers/base_tester.dart
+++ b/packages/stream_feeds_test/lib/src/testers/base_tester.dart
@@ -270,6 +270,7 @@ void testWithTester<S, T extends BaseTester<S>>(
             generateTestUserToken(user.id),
           ),
           feedsRestApi: feedsApi,
+          guestRestApi: feedsApi,
           wsProvider: (options) => webSocketChannel,
           config: FeedsConfig(
             cdnClient: FeedsCdnClient(cdnApi),


### PR DESCRIPTION
## Summary

- Guest users (`User.guest(id)`) now use a real guest JWT obtained from `POST /api/v2/guest` rather than an anonymous static token. The `TokenProvider.dynamic` callback creates a minimal API-key-only HTTP client, calls `DefaultApi.createGuest`, and wraps the `access_token` in a `UserToken` so the token manager and `AuthInterceptor` treat it as a JWT.
- Guest users can now call `connect()` and establish a full WebSocket session with read/write access.
- Anonymous users (`User.anonymous()`) are unchanged: static anonymous token, `stream-auth-type: anonymous` header, and no WebSocket connection.
- Added `docs/code_snippets/02_02_authentication.dart` with examples for regular JWT, dynamic token provider, guest, and anonymous auth patterns.

Closes FLU-373

## Test plan

- [x] `melos run analyze` — no issues
- [x] `melos run format` — no changes
- [x] `flutter test` in `packages/stream_feeds` — 392 tests pass
- [x] `dart analyze docs/code_snippets/02_02_authentication.dart` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guest authentication with automatic token retrieval and support for WebSocket connections.
  * Guest identities now update automatically when the backend assigns a different user ID.
  * Added examples for regular JWT login, dynamic token refresh, guest login, and anonymous read-only access.

* **Bug Fixes**
  * Connections now disconnect cleanly when authentication fails.

* **Documentation**
  * Documented the new guest authentication and WebSocket behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->