### PR TITLE
ci(repo): add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -28,6 +28,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build_and_deploy_web:
     name: Build and Deploy Dogfooding Web

--- a/.github/workflows/beta_version_analyze.yml
+++ b/.github/workflows/beta_version_analyze.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 3 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   # Does a sanity check on packages for the next beta version so we are not surprised by any breaking changes.
   analyze_beta_versions:

--- a/.github/workflows/legacy_version_analyze.yml
+++ b/.github/workflows/legacy_version_analyze.yml
@@ -22,6 +22,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   # Does a sanity check that packages at least pass analysis on the N-1
   # versions of Flutter stable if the package claims to support that version.

--- a/.github/workflows/pana.yml
+++ b/.github/workflows/pana.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   stream_feeds:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   conventional_pr_title:
     runs-on: ubuntu-latest

--- a/.github/workflows/stream_feeds_flutter_workflow.yml
+++ b/.github/workflows/stream_feeds_flutter_workflow.yml
@@ -19,6 +19,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   analyze:
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **9** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge
