### PR TITLE
ci(repo): Change permissions from read to write for contents

### DIFF
--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -29,7 +29,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build_and_deploy_web:


### PR DESCRIPTION
Fix for failing sample app publish
https://github.com/GetStream/stream-feeds-flutter/actions/runs/32143136169/job/95732665658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app distribution workflow permissions to support publishing release contents.
  * Deployment continues to run from the sample app directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->